### PR TITLE
Add ability to specify attachments (with streams) when sending a message

### DIFF
--- a/Fluxer.Net/ApiClient.cs
+++ b/Fluxer.Net/ApiClient.cs
@@ -1,12 +1,14 @@
-using System.Net;
-using System.Net.Http.Headers;
-using System.Reflection;
+using Fluxer.Net.Data;
 using Fluxer.Net.Data.Models;
+using Fluxer.Net.Extensions;
 using Fluxer.Net.RateLimiting;
 using Newtonsoft.Json;
 using Serilog;
 using Serilog.Core;
-using Fluxer.Net.Extensions;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Linq;
 
 namespace Fluxer.Net;
 
@@ -130,7 +132,8 @@ public class ApiClient
     /// <param name="authorize">Whether to include the Authorization header.</param>
     /// <returns>The deserialized response object.</returns>
     /// <exception cref="FluxerApiException">Thrown when <paramref name="throwOnNonSuccess"/> is true and the API returns a non-success status code.</exception>
-    public async Task<TResponse> MakeFluxerApiRequestRS<TResponse, TSend>(HttpMethod method, string route, TSend data, bool throwOnNonSuccess = false, bool authorize = true)
+    public async Task<TResponse> MakeFluxerApiRequestRS<TResponse, TSend>(HttpMethod method, string route, TSend data, bool throwOnNonSuccess = false, bool authorize = true,
+        ICollection<KeyValuePair<string, (HttpContent content, string? filename)>>? otherFormData = null)
     {
         var rawContent = JsonConvert.SerializeObject(data, new JsonSerializerSettings()
         {
@@ -140,9 +143,35 @@ public class ApiClient
         var req = new HttpRequestMessage()
         {
             Method = method,
-            Content = new StringContent(rawContent, new MediaTypeHeaderValue("application/json")),
             RequestUri = new(_config.RealApiBaseUrl + route)
         };
+        if (otherFormData != null)
+        {
+            var form = new MultipartFormDataContent
+            {
+                {
+                    new StringContent(rawContent, new MediaTypeHeaderValue("application/json")),
+                    "payload_json"
+                }
+            };
+            foreach (var (key, (content, filename)) in otherFormData)
+            {
+                if (key == "payload_json") continue;
+                if (string.IsNullOrEmpty(filename?.Trim()))
+                {
+                    form.Add(content, key);
+                }
+                else
+                {
+                    form.Add(content, key, filename);
+                }
+            }
+            req.Content = form;
+        }
+        else
+        {
+            req.Content = new StringContent(rawContent, new MediaTypeHeaderValue("application/json"));
+        }
         if (authorize)
             req.Headers.Add("Authorization", Token);
         var result = await HttpClient.SendAsync(req);
@@ -337,8 +366,21 @@ public class ApiClient
     public async Task<TResponse> SearchChannel<TRequest, TResponse>(ulong channelId, TRequest data)
         => await MakeFluxerApiRequestRS<TResponse, TRequest>(HttpMethod.Post, $"/channels/{channelId}/search", data, true);
 
-    public async Task<Message> SendMessage(ulong channelId, Message message)
-        => await MakeFluxerApiRequestRS<Message, Message>(HttpMethod.Post, $"/channels/{channelId}/messages", message, true);
+    public async Task<Message> SendMessage(ulong channelId, Message message, StreamAttachment[]? attachments = null)
+    {
+        if (attachments?.Length < 1)
+        {
+            return await MakeFluxerApiRequestRS<Message, Message>(HttpMethod.Post, $"/channels/{channelId}/messages", message, true);
+        }
+        var form = new List<KeyValuePair<string, (HttpContent content, string? filename)>>();
+        for (int i = 0; i < attachments.Length; i++)
+        {
+            attachments[i].Id = (ulong)i;
+            form.Add(new KeyValuePair<string, (HttpContent content, string? filename)>($"file[{i}]", (new StreamContent(attachments[i].Stream), attachments[i].Filename)));
+        }
+        message.Attachments = attachments.Cast<Attachment>().ToList();
+        return await MakeFluxerApiRequestRS<Message, Message>(HttpMethod.Post, $"/channels/{channelId}/messages", message, true);
+    }
 
     public async Task<Message> EditMessage(ulong channelId, ulong messageId, Message message)
         => await MakeFluxerApiRequestRS<Message, Message>(HttpMethod.Patch, $"/channels/{channelId}/messages/{messageId}", message, true);

--- a/Fluxer.Net/Data/StreamAttachment.cs
+++ b/Fluxer.Net/Data/StreamAttachment.cs
@@ -1,0 +1,10 @@
+﻿using Fluxer.Net.Data.Models;
+using Newtonsoft.Json;
+
+namespace Fluxer.Net.Data;
+
+public class StreamAttachment : Attachment
+{
+    [JsonIgnore]
+    public required Stream Stream { get; init; }
+}


### PR DESCRIPTION
This PR aims to resolve #22 

I could've implemented this in a more neat way, but currently the message type provided to ApiClient for sending messages is the same message type that's received by the API (like what Discord.NET does). It would've been neater if those two were separated, but I assume that's something to resolve in a later release.