### PR TITLE
[Commands/ModuleBase] Properly reply to message that invoked the command

### DIFF
--- a/Fluxer.Net/Commands/ModuleBase.cs
+++ b/Fluxer.Net/Commands/ModuleBase.cs
@@ -26,21 +26,35 @@ public abstract class ModuleBase
 	{
 	}
 
-	/// <summary>
-	/// Sends a message to the channel the command was executed in.
-	/// </summary>
-	/// <param name="content">The message content.</param>
-	protected async Task<Message> ReplyAsync(string content)
+    /// <summary>
+    /// Sends a message to the channel the command was executed in,
+	/// and reply to the message that invoked the command.
+    /// </summary>
+    /// <param name="content">The message content.</param>
+    protected async Task<Message> ReplyAsync(string content)
 	{
-		return await Context.Client.SendMessage(Context.ChannelId, new Message { Content = content });
+		return await ReplyAsync(new Message
+		{
+			Content = content
+		});
 	}
 
 	/// <summary>
-	/// Sends a message to the channel the command was executed in.
+	/// Sends a message to the channel the command was executed in,
+	/// and reply to the message that invoked the command.
 	/// </summary>
 	/// <param name="message">The message to send.</param>
 	protected async Task<Message> ReplyAsync(Message message)
 	{
+		// don't override ref
+		if (message.Reference != null)
+		{
+			message.Reference = new MessageRef()
+			{
+				ChannelId = Context.Message.ChannelId,
+				MessageId = Context.Message.Id
+			};
+        }
 		return await Context.Client.SendMessage(Context.ChannelId, message);
 	}
 }


### PR DESCRIPTION
This PR updates the `ReplyAsync` method in `ModuleBase` so it actually replies to the message that invoked the command, instead of sending a message in the channel it was invoked in.

This is how Reply-like methods are implemented in other chat platform libraries (e.g: Discord.NET)