### PR TITLE
Update Guild Model

### DIFF
--- a/Fluxer.Net/Data/Enums/GuildSplashCardAlignment.cs
+++ b/Fluxer.Net/Data/Enums/GuildSplashCardAlignment.cs
@@ -1,0 +1,11 @@
+﻿namespace Fluxer.Net.Data.Enums;
+
+/// <summary>
+/// Splash card alignment types for <see cref="Models.Guild.SplashCardAligment"/>
+/// </summary>
+public enum GuildSplashCardAlignment
+{
+    Center = 0,
+    Left = 1,
+    Right = 2
+}

--- a/Fluxer.Net/Data/Models/Guild.cs
+++ b/Fluxer.Net/Data/Models/Guild.cs
@@ -1,3 +1,4 @@
+using Fluxer.Net.Data.Enums;
 using Newtonsoft.Json;
 
 namespace Fluxer.Net.Data.Models;
@@ -22,10 +23,34 @@ public class Guild
 	[JsonProperty("banner")]
 	public string? BannerHash { get; set; }
 
-	[JsonProperty("splash")]
+    [JsonProperty("banner_width")]
+    public int? BannerWidth { get; set; }
+
+    [JsonProperty("banner_height")]
+    public int? BannerHeight { get; set; }
+
+    [JsonProperty("embed_splash")]
+	public string? EmbedSplashHash { get; set; }
+
+    [JsonProperty("embed_splash_width")]
+	public int? EmbedSplashWidth { get; set; }
+    
+    [JsonProperty("embed_splash_height")]
+    public int? EmbedSplashHeight { get; set; }
+
+    [JsonProperty("splash")]
 	public string? SplashHash { get; set; }
 
-	[JsonProperty("features")]
+    [JsonProperty("splash_width")]
+	public int? SplashWidth { get; set; }
+	
+    [JsonProperty("splash_height")]
+	public int? SplashHeight { get; set; }
+
+    [JsonProperty("splash_card_alignment")]
+	public GuildSplashCardAlignment SplashCardAligment { get; set; }
+
+    [JsonProperty("features")]
 	public HashSet<string>? Features { get; set; }
 
 	[JsonProperty("verification_level")]
@@ -69,4 +94,7 @@ public class Guild
 
 	[JsonProperty("audit_logs_indexed_at")]
 	public DateTime? AuditLogsIndexedAt { get; set; }
+
+	[JsonProperty("message_history_cutoff")]
+	public DateTime? MessageHistoryCutoff { get; set; }
 }


### PR DESCRIPTION
This PR updates the Guild model to match what's currently returned by the API.
https://docs.fluxer.app/resources/guilds#guildresponse

I was unsure if I should remove the property for `audit_logs_indexed_at` since that seems like it's not returned by `GuildResponse` in the Fluxer API docs.

I also created an enum for the `SplashCardAlignment` property. I found the definitions for the values [here](https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/constants/src/GuildConstants.tsx#L36). (packages/constants/src/GuildConstants.tsx)