### PR TITLE
Create Github Actions Workflow for Build+Test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build project and run unit tests
+
+on:
+  push:
+  pull_request:
+    branches: [ main, dev ]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            7.0.x
+            8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      # TODO: make separate workflow just for unit test
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build project and run unit tests
 on:
   push:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ release, dev ]
   workflow_dispatch:
 
 jobs:

--- a/Fluxer.Net.Test/Fluxer.Net.Test.csproj
+++ b/Fluxer.Net.Test/Fluxer.Net.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Fluxer.Net/Commands/ModuleBase.cs
+++ b/Fluxer.Net/Commands/ModuleBase.cs
@@ -1,4 +1,5 @@
 using Fluxer.Net.Data.Models;
+using Fluxer.Net.Data.Responses;
 
 namespace Fluxer.Net.Commands;
 
@@ -30,7 +31,7 @@ public abstract class ModuleBase
 	/// Sends a message to the channel the command was executed in.
 	/// </summary>
 	/// <param name="content">The message content.</param>
-	protected async Task<Message> ReplyAsync(string content)
+	protected async Task<MessageBaseResponse> ReplyAsync(string content)
 	{
 		return await Context.Client.SendMessage(Context.ChannelId, new Message { Content = content });
 	}
@@ -39,7 +40,7 @@ public abstract class ModuleBase
 	/// Sends a message to the channel the command was executed in.
 	/// </summary>
 	/// <param name="message">The message to send.</param>
-	protected async Task<Message> ReplyAsync(Message message)
+	protected async Task<MessageBaseResponse> ReplyAsync(Message message)
 	{
 		return await Context.Client.SendMessage(Context.ChannelId, message);
 	}


### PR DESCRIPTION
This PR adds a new Github Actions Workflow to build Fluxer.Net and run the unit tests whenever a commit is made, or on any PR into `release` or `dev`.

This also fixes a lil bug I missed in #38 