### PR TITLE
v1.7.0

### DIFF
--- a/Fluxer.Net.Example/Program.cs
+++ b/Fluxer.Net.Example/Program.cs
@@ -83,7 +83,7 @@ Log.Debug("Config file loaded successfully.");
 //   - Full coverage of 150+ Fluxer API endpoints
 //   - Shared logging configuration with the gateway
 
-var client = new FluxerClient(config["Token"], new()
+FluxerClient client = new FluxerClient(config["Token"], new()
 {
     ReconnectAttemptDelay = 2,  // Reconnect quickly if connection drops
     RestSerilog = Log.Logger as Logger,  // Use our configured logger
@@ -116,7 +116,7 @@ var client = new FluxerClient(config["Token"], new()
 //   - Precondition support (RequireOwner, RequireContext, etc.)
 //   - Sync/Async execution modes
 
-var commands = new CommandService(
+CommandService commands = new CommandService(
     logger: Log.Logger as Logger,  // Use our configured logger
     services: null  // No dependency injection for this example
 );
@@ -201,7 +201,7 @@ client.Gateway.MessageCreate += async messageData =>
             argPos = 1; // Skip the prefix character
 
             // Create a command context with all the necessary information
-            var context = new CommandContext(client, messageData);
+            CommandContext context = new CommandContext(client, messageData);
 
             // Execute the command
             var result = await commands.ExecuteAsync(context, argPos);

--- a/Fluxer.Net.Test/Json/AuditLogResponseItemChangeTest.cs
+++ b/Fluxer.Net.Test/Json/AuditLogResponseItemChangeTest.cs
@@ -157,9 +157,9 @@ public class AuditLogResponseItemChangeTest
         Assert.That(dataRemoveOnly.NewValue?.GetType(), Is.EqualTo(typeof(PermissionDiffSchemaJson)));
         Assert.That(dataAddAndRemove.NewValue?.GetType(), Is.EqualTo(typeof(PermissionDiffSchemaJson)));
 
-        var valueAddOnly = (PermissionDiffSchemaJson)dataAddOnly.NewValue!;
-        var valueTypedRemoveOnly = (PermissionDiffSchemaJson)dataRemoveOnly.NewValue!;
-        var valueAddAndRemove = (PermissionDiffSchemaJson)dataAddAndRemove.NewValue!;
+        PermissionDiffSchemaJson valueAddOnly = (PermissionDiffSchemaJson)dataAddOnly.NewValue!;
+        PermissionDiffSchemaJson valueTypedRemoveOnly = (PermissionDiffSchemaJson)dataRemoveOnly.NewValue!;
+        PermissionDiffSchemaJson valueAddAndRemove = (PermissionDiffSchemaJson)dataAddAndRemove.NewValue!;
 
         Assert.That(dataAddOnly.Key, Is.EqualTo("permissions_diff"));
         Assert.That(dataAddOnly.NewValue.GetType, Is.EqualTo(typeof(PermissionDiffSchemaJson)));

--- a/Fluxer.Net/Commands/CommandService.cs
+++ b/Fluxer.Net/Commands/CommandService.cs
@@ -67,7 +67,7 @@ public class CommandService
         if (!type.IsSubclassOf(typeof(ModuleBase)))
             throw new ArgumentException($"Type {type.Name} must inherit from ModuleBase", nameof(type));
 
-        var module = new ModuleInfo(type);
+        ModuleInfo module = new ModuleInfo(type);
         module.Build();
 
         _modules.Add(module);
@@ -94,7 +94,7 @@ public class CommandService
             return ExecuteResult.FromError(CommandError.ParseFailed, "No command specified");
 
         var commandName = parts[0].ToLowerInvariant();
-        var argList = parts.Skip(1).ToList();
+        List<string> argList = parts.Skip(1).ToList();
 
         // Find matching command
         CommandInfo? matchedCommand = null;

--- a/Fluxer.Net/Commands/ModuleInfo.cs
+++ b/Fluxer.Net/Commands/ModuleInfo.cs
@@ -39,7 +39,7 @@ public class ModuleInfo
 
 	internal void Build()
 	{
-		var commands = new List<CommandInfo>();
+        List<CommandInfo> commands = new List<CommandInfo>();
 
 		foreach (var method in Type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
 		{

--- a/Fluxer.Net/Data/Apps/Application.cs
+++ b/Fluxer.Net/Data/Apps/Application.cs
@@ -18,7 +18,7 @@ public class Application : PartialApplication, IApplication
 
     public static Application Create(FluxerBaseClient client, ApplicationJson json)
     {
-        var data = new Application(client);
+        Application data = new Application(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Apps/PartialApplication.cs
+++ b/Fluxer.Net/Data/Apps/PartialApplication.cs
@@ -31,7 +31,7 @@ public class PartialApplication : Entity, IPartialApplication
 
     public static PartialApplication Create(FluxerBaseClient client, PartialApplicationJson json)
     {
-        var data = new PartialApplication(client);
+        PartialApplication data = new PartialApplication(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Auth/AuthSession.cs
+++ b/Fluxer.Net/Data/Auth/AuthSession.cs
@@ -34,7 +34,7 @@ public class AuthSession : Entity, IAuthSession
 
     public static AuthSession Create(FluxerBaseClient client, AuthSessionJson json)
     {
-        var data = new AuthSession(client);
+        AuthSession data = new AuthSession(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Auth/Login.cs
+++ b/Fluxer.Net/Data/Auth/Login.cs
@@ -16,7 +16,7 @@ public class Login : Entity, ILogin
 
     public static Login Create(FluxerBaseClient client, LoginJson json)
     {
-        var data = new Login(client);
+        Login data = new Login(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Channels/CategoryChannel.cs
+++ b/Fluxer.Net/Data/Channels/CategoryChannel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluxer.Net;
 
-public class CategoryChannel : Channel
+public class CategoryChannel : GuildChannel
 {
     internal CategoryChannel(FluxerBaseClient client) : base(client)
     {

--- a/Fluxer.Net/Data/Channels/Channel.cs
+++ b/Fluxer.Net/Data/Channels/Channel.cs
@@ -7,6 +7,9 @@ public class Channel : Entity, IChannel
     public ulong Id { get; internal set; }
 
     /// <inheritdoc />
+    public string Mention => $"<#{Id}>";
+
+    /// <inheritdoc />
     public ulong? GuildId { get; internal set; }
 
     /// <inheritdoc />

--- a/Fluxer.Net/Data/Channels/ChannelJson.cs
+++ b/Fluxer.Net/Data/Channels/ChannelJson.cs
@@ -15,6 +15,10 @@ public class ChannelJson : IChannel
     public ulong Id { get; set; }
 
     /// <inheritdoc />
+    [JsonIgnore]
+    public string Mention => $"<#{Id}>";
+
+    /// <inheritdoc />
     [JsonProperty("guild_id")]
     public ulong? GuildId { get; set; }
 

--- a/Fluxer.Net/Data/Channels/ChannelPin.cs
+++ b/Fluxer.Net/Data/Channels/ChannelPin.cs
@@ -18,7 +18,7 @@ public class ChannelPin : Entity, IChannelPin
 
     public static ChannelPin Create(FluxerBaseClient client, ChannelPinJson json)
     {
-        var data = new ChannelPin(client);
+        ChannelPin data = new ChannelPin(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Channels/ChannelPins.cs
+++ b/Fluxer.Net/Data/Channels/ChannelPins.cs
@@ -18,7 +18,7 @@ public class ChannelPins : Entity, IChannelPins
 
     public static ChannelPins Create(FluxerBaseClient client, ChannelPinsJson json)
     {
-        var data = new ChannelPins(client);
+        ChannelPins data = new ChannelPins(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Channels/GuildChannel.cs
+++ b/Fluxer.Net/Data/Channels/GuildChannel.cs
@@ -1,0 +1,21 @@
+﻿namespace Fluxer.Net;
+
+public class GuildChannel : Channel, IGuildChannel
+{
+    internal GuildChannel(FluxerBaseClient client) : base(client)
+    {
+
+    }
+
+    public static GuildChannel Create(FluxerBaseClient client, ChannelJson json)
+    {
+        var data = new GuildChannel(client);
+        data.Update(client, json);
+        return data;
+    }
+
+    internal void Update(FluxerBaseClient client, ChannelJson json)
+    {
+        base.Update(client, json);
+    }
+}

--- a/Fluxer.Net/Data/Channels/IChannel.cs
+++ b/Fluxer.Net/Data/Channels/IChannel.cs
@@ -8,6 +8,11 @@ public interface IChannel
     ulong Id { get; }
 
     /// <summary>
+    /// Get the mention for this channel.
+    /// </summary>
+    string Mention { get; }
+
+    /// <summary>
     /// The unique identifier (snowflake) for guild of this channel.
     /// </summary>
     ulong? GuildId { get; }

--- a/Fluxer.Net/Data/Channels/IGuildChannel.cs
+++ b/Fluxer.Net/Data/Channels/IGuildChannel.cs
@@ -1,0 +1,5 @@
+﻿namespace Fluxer.Net;
+
+public interface IGuildChannel
+{
+}

--- a/Fluxer.Net/Data/Channels/LinkChannel.cs
+++ b/Fluxer.Net/Data/Channels/LinkChannel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluxer.Net;
 
-public class LinkChannel : Channel
+public class LinkChannel : GuildChannel
 {
     internal LinkChannel(FluxerBaseClient client) : base(client)
     {

--- a/Fluxer.Net/Data/Channels/PermissionOverwrite.cs
+++ b/Fluxer.Net/Data/Channels/PermissionOverwrite.cs
@@ -22,7 +22,7 @@ public class PermissionOverwrite : Entity, IPermissionOverwrite
 
     public static PermissionOverwrite Create(FluxerBaseClient client, PermissionOverwriteJson json)
     {
-        var data = new PermissionOverwrite(client);
+        PermissionOverwrite data = new PermissionOverwrite(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Channels/SocketChannel.cs
+++ b/Fluxer.Net/Data/Channels/SocketChannel.cs
@@ -1,0 +1,22 @@
+﻿namespace Fluxer.Net;
+
+public class SocketChannel : Channel
+{
+    internal SocketChannel(FluxerBaseClient client) : base(client)
+    {
+
+    }
+
+    public static SocketChannel Create(FluxerBaseClient client, ChannelJson json, ulong guildId)
+    {
+        SocketChannel data = new SocketChannel(client);
+        data.GuildId = guildId;
+        data.Update(client, json);
+        return data;
+    }
+
+    internal void Update(FluxerBaseClient client, ChannelJson json)
+    {
+        base.Update(client, json);
+    }
+}

--- a/Fluxer.Net/Data/Channels/TextChannel.cs
+++ b/Fluxer.Net/Data/Channels/TextChannel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluxer.Net;
 
-public class TextChannel : Channel, ITextable
+public class TextChannel : GuildChannel, ITextable
 {
     internal TextChannel(FluxerBaseClient client) : base(client)
     {

--- a/Fluxer.Net/Data/Channels/VoiceChannel.cs
+++ b/Fluxer.Net/Data/Channels/VoiceChannel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fluxer.Net;
 
-internal class VoiceChannel : Channel
+internal class VoiceChannel : GuildChannel
 {
     internal VoiceChannel(FluxerBaseClient client) : base(client)
     {

--- a/Fluxer.Net/Data/Embeds/Embed.cs
+++ b/Fluxer.Net/Data/Embeds/Embed.cs
@@ -71,7 +71,7 @@ public class Embed : IEmbed
 
     public static Embed Create(FluxerBaseClient client, EmbedJson json)
     {
-        var data = new Embed(client);
+        Embed data = new Embed(client);
         data.Update(client, json);
         return data;
     }
@@ -116,7 +116,7 @@ public class EmbedField : IEmbedField
 
     public static EmbedField Create(FluxerBaseClient client, EmbedFieldJson json)
     {
-        var data = new EmbedField(client);
+        EmbedField data = new EmbedField(client);
         data.Update(client, json);
         return data;
     }
@@ -152,7 +152,7 @@ public class EmbedAuthor : IEmbedAuthor
         if (json == null)
             return null;
 
-        var data = new EmbedAuthor(client);
+        EmbedAuthor data = new EmbedAuthor(client);
         data.Update(client, json);
         return data;
     }
@@ -186,7 +186,7 @@ public class EmbedFooter : IEmbedFooter
         if (json == null)
             return null;
 
-        var data = new EmbedFooter(client);
+        EmbedFooter data = new EmbedFooter(client);
         data.Update(client, json);
         return data;
     }
@@ -240,7 +240,7 @@ public class EmbedMedia : IEmbedMedia
         if (json == null)
             return null;
 
-        var data = new EmbedMedia(client);
+        EmbedMedia data = new EmbedMedia(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Embeds/EmbedBuilder.cs
+++ b/Fluxer.Net/Data/Embeds/EmbedBuilder.cs
@@ -268,7 +268,7 @@ public class EmbedBuilder
     /// <returns>The current builder.</returns>
     public EmbedBuilder WithAuthor(string name, string? iconUrl = null, string? url = null)
     {
-        var author = new EmbedAuthorBuilder
+        EmbedAuthorBuilder author = new EmbedAuthorBuilder
         {
             Name = name,
             IconUrl = iconUrl,
@@ -285,7 +285,7 @@ public class EmbedBuilder
     /// <returns>The current builder.</returns>
     public EmbedBuilder WithAuthor(Action<EmbedAuthorBuilder> action)
     {
-        var author = new EmbedAuthorBuilder();
+        EmbedAuthorBuilder author = new EmbedAuthorBuilder();
         action(author);
         Author = author;
         return this;
@@ -310,7 +310,7 @@ public class EmbedBuilder
     /// <returns>The current builder.</returns>
     public EmbedBuilder WithFooter(string text, string? iconUrl = null)
     {
-        var footer = new EmbedFooterBuilder
+        EmbedFooterBuilder footer = new EmbedFooterBuilder
         {
             Text = text,
             IconUrl = iconUrl
@@ -326,7 +326,7 @@ public class EmbedBuilder
     /// <returns>The current builder.</returns>
     public EmbedBuilder WithFooter(Action<EmbedFooterBuilder> action)
     {
-        var footer = new EmbedFooterBuilder();
+        EmbedFooterBuilder footer = new EmbedFooterBuilder();
         action(footer);
         Footer = footer;
         return this;
@@ -357,7 +357,7 @@ public class EmbedBuilder
     /// <exception cref="ArgumentException">Field count exceeds <see cref="MaxFieldCount"/>.</exception>
     public EmbedBuilder AddField(string name, object value, bool inline = false)
     {
-        var field = new EmbedFieldBuilder
+        EmbedFieldBuilder field = new EmbedFieldBuilder
         {
             Name = name,
             Value = value?.ToString() ?? "",
@@ -374,7 +374,7 @@ public class EmbedBuilder
     /// <exception cref="ArgumentException">Field count exceeds <see cref="MaxFieldCount"/>.</exception>
     public EmbedBuilder AddField(Action<EmbedFieldBuilder> action)
     {
-        var field = new EmbedFieldBuilder();
+        EmbedFieldBuilder field = new EmbedFieldBuilder();
         action(field);
         return AddField(field);
     }
@@ -398,7 +398,7 @@ public class EmbedBuilder
         if (!string.IsNullOrEmpty(ImageUrl) && !IsValidUrl(ImageUrl))
             throw new InvalidOperationException("Image URL must include a protocol (http:// or https://).");
 
-        var embed = new EmbedRequest
+        EmbedRequest embed = new EmbedRequest
         {
             Title = Title,
             Description = Description,

--- a/Fluxer.Net/Data/Expressions/Emoji.cs
+++ b/Fluxer.Net/Data/Expressions/Emoji.cs
@@ -19,7 +19,7 @@ public class Emoji : Entity, IEmoji
 
     public static Emoji Create(FluxerBaseClient client, EmojiJson json)
     {
-        var data = new Emoji(client);
+        Emoji data = new Emoji(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Expressions/GuildEmoji.cs
+++ b/Fluxer.Net/Data/Expressions/GuildEmoji.cs
@@ -19,7 +19,7 @@ public class GuildEmoji : Emoji, IGuildEmoji
 
     public static GuildEmoji Create(FluxerBaseClient client, GuildEmojiJson json, ulong guildId)
     {
-        var data = new GuildEmoji(client);
+        GuildEmoji data = new GuildEmoji(client);
         data.GuildId = guildId;
         data.Update(client, json);
         return data;

--- a/Fluxer.Net/Data/Expressions/GuildSticker.cs
+++ b/Fluxer.Net/Data/Expressions/GuildSticker.cs
@@ -22,7 +22,7 @@ public class GuildSticker : Sticker, IGuildSticker
 
     public static GuildSticker Create(FluxerBaseClient client, GuildStickerJson json, ulong guildId)
     {
-        var data = new GuildSticker(client);
+        GuildSticker data = new GuildSticker(client);
         data.GuildId = guildId;
         data.Update(client, json);
         return data;

--- a/Fluxer.Net/Data/Expressions/Sticker.cs
+++ b/Fluxer.Net/Data/Expressions/Sticker.cs
@@ -19,7 +19,7 @@ public class Sticker : Entity, ISticker
 
     public static Sticker Create(FluxerBaseClient client, StickerJson json)
     {
-        var data = new Sticker(client);
+        Sticker data = new Sticker(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Gifs/FavouriteGif.cs
+++ b/Fluxer.Net/Data/Gifs/FavouriteGif.cs
@@ -61,7 +61,7 @@ public class FavouriteGif : Entity, IFavouriteGif
 
     public static FavouriteGif Create(FluxerBaseClient client, FavouriteGifJson json)
     {
-        var data = new FavouriteGif(client);
+        FavouriteGif data = new FavouriteGif(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Gifs/Gif.cs
+++ b/Fluxer.Net/Data/Gifs/Gif.cs
@@ -31,7 +31,7 @@ public class Gif : Entity
 
     public static Gif Create(FluxerBaseClient client, GifJson json)
     {
-        var data = new Gif(client);
+        Gif data = new Gif(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Gifs/GifCategory.cs
+++ b/Fluxer.Net/Data/Gifs/GifCategory.cs
@@ -19,7 +19,7 @@ public class GifCategory : Entity, IGifCategory
 
     public static GifCategory Create(FluxerBaseClient client, GifCategoryJson json)
     {
-        var data = new GifCategory(client);
+        GifCategory data = new GifCategory(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/Guild.cs
+++ b/Fluxer.Net/Data/Guilds/Guild.cs
@@ -52,7 +52,7 @@ public class Guild : PartialGuild, IGuild
 
     public static Guild Create(FluxerBaseClient client, GuildJson json)
     {
-        var data = new Guild(client);
+        Guild data = new Guild(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/Members/GuildBan.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildBan.cs
@@ -26,7 +26,7 @@ public class GuildBan : Entity, IGuildBan
 
     public static GuildBan Create(FluxerBaseClient client, GuildBanJson json)
     {
-        var data = new GuildBan(client);
+        GuildBan data = new GuildBan(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
@@ -64,6 +64,12 @@ public class GuildMember : Entity, IGuildMember
     public bool IsTemporary { get; internal set; }
 
     /// <inheritdoc />
+    public string GetCurrentName()
+    {
+        return Nickname ?? User.DisplayName ?? User.Username;
+    }
+
+    /// <inheritdoc />
     public string GetDefaultAvatarUrl()
     {
         return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";

--- a/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
@@ -69,6 +69,24 @@ public class GuildMember : Entity, IGuildMember
         return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";
     }
 
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return User.GetAvatarUrl();
+
+        return $"{Client.Config.MediaUrl}/avatars/{UserId}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash) && string.IsNullOrEmpty(User.AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
+
     IUser IGuildMember.User => User;
 
     internal GuildMember(FluxerBaseClient client) : base(client)

--- a/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
@@ -68,7 +68,7 @@ public class GuildMember : Entity, IGuildMember
 
     public static GuildMember Create(FluxerBaseClient client, GuildMemberJson json)
     {
-        var data = new GuildMember(client);
+        GuildMember data = new GuildMember(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
@@ -63,6 +63,12 @@ public class GuildMember : Entity, IGuildMember
     /// <inheritdoc />
     public bool IsTemporary { get; internal set; }
 
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";
+    }
+
     IUser IGuildMember.User => User;
 
     internal GuildMember(FluxerBaseClient client) : base(client)

--- a/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMember.cs
@@ -3,7 +3,11 @@
 /// <inheritdoc />
 public class GuildMember : Entity, IGuildMember
 {
+    /// <inheritdoc />
     public ulong UserId => User.Id;
+
+    /// <inheritdoc />
+    public string Mention => $"<@{UserId}>";
 
     /// <inheritdoc />
     public ulong GuildId { get; internal set; }

--- a/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
@@ -5,7 +5,13 @@ namespace Fluxer.Net;
 /// <inheritdoc />
 public class GuildMemberJson : IGuildMember
 {
+    /// <inheritdoc />
+    [JsonIgnore]
     public ulong UserId => User.Id;
+
+    /// <inheritdoc />
+    [JsonIgnore]
+    public string Mention => $"<@{UserId}>";
 
     /// <inheritdoc />
     [JsonProperty("guild_id")]

--- a/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
@@ -86,6 +86,12 @@ public class GuildMemberJson : IGuildMember
     public bool IsTemporary { get; set; }
 
     /// <inheritdoc />
+    public string GetCurrentName()
+    {
+        return Nickname ?? User.DisplayName ?? User.Username;
+    }
+
+    /// <inheritdoc />
     public string GetDefaultAvatarUrl()
     {
         return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";

--- a/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
@@ -85,5 +85,12 @@ public class GuildMemberJson : IGuildMember
     [JsonProperty("temporary")]
     public bool IsTemporary { get; set; }
 
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";
+    }
+
     IUser IGuildMember.User => User;
+
 }

--- a/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
+++ b/Fluxer.Net/Data/Guilds/Members/GuildMemberJson.cs
@@ -91,6 +91,24 @@ public class GuildMemberJson : IGuildMember
         return $"https://fluxerstatic.com/avatars/{UserId % 6}.png";
     }
 
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return User.GetAvatarUrl();
+
+        return $"https://fluxerusercontent.com/avatars/{UserId}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash) && string.IsNullOrEmpty(User.AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
+
     IUser IGuildMember.User => User;
 
 }

--- a/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
@@ -85,4 +85,14 @@ public interface IGuildMember
     /// Get the default avatar for the user.
     /// </summary>
     string GetDefaultAvatarUrl();
+
+    /// <summary>
+    /// Get the members's avatar.
+    /// </summary>
+    string? GetAvatarUrl(int size);
+
+    /// <summary>
+    /// Get the members's avatar or fallback to default.
+    /// </summary>
+    string GetAvatarOrDefaultUrl(int size);
 }

--- a/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
@@ -3,10 +3,23 @@
 public interface IGuildMember
 {
     /// <summary>
+    /// User id for this member.
+    /// </summary>
+    ulong UserId { get; }
+
+    /// <summary>
     /// Guild id that the user is in.
     /// </summary>
     ulong GuildId { get; }
 
+    /// <summary>
+    /// Get the mention for the user.
+    /// </summary>
+    string Mention { get; }
+
+    /// <summary>
+    /// User data for the member.
+    /// </summary>
     IUser User { get; }
 
     /// <summary>

--- a/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
@@ -82,6 +82,11 @@ public interface IGuildMember
     bool IsTemporary { get; }
 
     /// <summary>
+    /// Get the members's current nickname, display name or username.
+    /// </summary>
+    string GetCurrentName();
+
+    /// <summary>
     /// Get the default avatar for the user.
     /// </summary>
     string GetDefaultAvatarUrl();

--- a/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/IGuildMember.cs
@@ -80,4 +80,9 @@ public interface IGuildMember
     bool IsPremiumSanitized { get; }
 
     bool IsTemporary { get; }
+
+    /// <summary>
+    /// Get the default avatar for the user.
+    /// </summary>
+    string GetDefaultAvatarUrl();
 }

--- a/Fluxer.Net/Data/Guilds/Members/IRole.cs
+++ b/Fluxer.Net/Data/Guilds/Members/IRole.cs
@@ -8,6 +8,11 @@ public interface IRole
     ulong Id { get; }
 
     /// <summary>
+    /// Get the mention for this role.
+    /// </summary>
+    string Mention { get; }
+
+    /// <summary>
     /// The name of the role.
     /// </summary>
     string Name { get; }

--- a/Fluxer.Net/Data/Guilds/Members/Role.cs
+++ b/Fluxer.Net/Data/Guilds/Members/Role.cs
@@ -10,6 +10,9 @@ public class Role : Entity, IRole
     public ulong Id { get; internal set; }
 
     /// <inheritdoc />
+    public string Mention => $"<@&{Id}>";
+
+    /// <inheritdoc />
     public string Name { get; internal set; }
 
     /// <inheritdoc />

--- a/Fluxer.Net/Data/Guilds/Members/Role.cs
+++ b/Fluxer.Net/Data/Guilds/Members/Role.cs
@@ -37,7 +37,7 @@ public class Role : Entity, IRole
 
     public static Role Create(FluxerBaseClient client, RoleJson json, ulong guildId)
     {
-        var data = new Role(client);
+        Role data = new Role(client);
         data.GuildId = guildId;
         data.Update(client, json);
         return data;

--- a/Fluxer.Net/Data/Guilds/Members/RoleJson.cs
+++ b/Fluxer.Net/Data/Guilds/Members/RoleJson.cs
@@ -10,6 +10,10 @@ public class RoleJson : IRole
     public ulong Id { get; set; }
 
     /// <inheritdoc />
+    [JsonIgnore]
+    public string Mention => $"<@&{Id}>";
+
+    /// <inheritdoc />
     [JsonProperty("name")]
     public string Name { get; set; }
 

--- a/Fluxer.Net/Data/Guilds/Members/SocketGuildMember.cs
+++ b/Fluxer.Net/Data/Guilds/Members/SocketGuildMember.cs
@@ -1,0 +1,23 @@
+﻿namespace Fluxer.Net;
+
+public class SocketGuildMember : GuildMember
+{
+    public SocketGuild Guild { get; internal set; }
+
+    internal SocketGuildMember(FluxerBaseClient client) : base(client)
+    {
+
+    }
+
+    public static SocketGuildMember Create(FluxerBaseClient client, GuildMemberJson json)
+    {
+        SocketGuildMember data = new SocketGuildMember(client);
+        data.Update(client, json);
+        return data;
+    }
+
+    internal void Update(FluxerBaseClient client, GuildMemberJson json)
+    {
+        base.Update(client, json);
+    }
+}

--- a/Fluxer.Net/Data/Guilds/Members/SocketRole.cs
+++ b/Fluxer.Net/Data/Guilds/Members/SocketRole.cs
@@ -1,0 +1,22 @@
+﻿namespace Fluxer.Net;
+
+public class SocketRole : Role
+{
+    internal SocketRole(FluxerBaseClient client) : base(client)
+    {
+
+    }
+
+    public static SocketRole Create(FluxerBaseClient client, RoleJson json, ulong guildId)
+    {
+        SocketRole data = new SocketRole(client);
+        data.GuildId = guildId;
+        data.Update(client, json);
+        return data;
+    }
+
+    internal void Update(FluxerBaseClient client, RoleJson json)
+    {
+        base.Update(client, json);
+    }
+}

--- a/Fluxer.Net/Data/Guilds/PartialGuild.cs
+++ b/Fluxer.Net/Data/Guilds/PartialGuild.cs
@@ -54,7 +54,7 @@ public class PartialGuild : Entity, IPartialGuild
 
     public static PartialGuild Create(FluxerBaseClient client, PartialGuildJson json)
     {
-        var data = new PartialGuild(client);
+        PartialGuild data = new PartialGuild(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/Settings/GuildVanityUrl.cs
+++ b/Fluxer.Net/Data/Guilds/Settings/GuildVanityUrl.cs
@@ -16,7 +16,7 @@ public class GuildVanityUrl : Entity, IGuildVanityUrl
 
     public static GuildVanityUrl Create(FluxerBaseClient client, GuildVanityUrlJson json)
     {
-        var data = new GuildVanityUrl(client);
+        GuildVanityUrl data = new GuildVanityUrl(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Guilds/SocketGuild.cs
+++ b/Fluxer.Net/Data/Guilds/SocketGuild.cs
@@ -1,0 +1,31 @@
+﻿namespace Fluxer.Net;
+
+/// <summary>
+/// Cached guild from the gateway.
+/// </summary>
+public class SocketGuild : Guild
+{
+    /// <summary>
+    /// Cached current logged in member for the guild.
+    /// </summary>
+    public SocketGuildMember CurrentMember { get; internal set; }
+
+    internal SocketGuild(FluxerBaseClient client) : base(client)
+    {
+
+    }
+
+    public static SocketGuild Create(FluxerBaseClient client, GuildJson json, SocketGuildMember member)
+    {
+        SocketGuild data = new SocketGuild(client);
+        data.CurrentMember = member;
+        data.CurrentMember.Guild = data;
+        data.Update(client, json);
+        return data;
+    }
+
+    internal void Update(FluxerBaseClient client, GuildJson json)
+    {
+        base.Update(client, json);
+    }
+}

--- a/Fluxer.Net/Data/Invites/Invite.cs
+++ b/Fluxer.Net/Data/Invites/Invite.cs
@@ -22,7 +22,7 @@ public class Invite : PartialInvite, IInvite
 
     public static Invite Create(FluxerBaseClient client, InviteJson json)
     {
-        var data = new Invite(client);
+        Invite data = new Invite(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Invites/PartialInvite.cs
+++ b/Fluxer.Net/Data/Invites/PartialInvite.cs
@@ -37,7 +37,7 @@ public class PartialInvite : Entity, IPartialInvite
 
     public static PartialInvite Create(FluxerBaseClient client, PartialInviteJson json)
     {
-        var data = new PartialInvite(client);
+        PartialInvite data = new PartialInvite(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Messages/Attachment.cs
+++ b/Fluxer.Net/Data/Messages/Attachment.cs
@@ -64,7 +64,7 @@ public class Attachment : Entity, IAttachment
 
     public static Attachment Create(FluxerBaseClient client, AttachmentJson json)
     {
-        var data = new Attachment(client);
+        Attachment data = new Attachment(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Messages/Message.cs
+++ b/Fluxer.Net/Data/Messages/Message.cs
@@ -86,7 +86,7 @@ public class Message : Entity, IMessage
 
     public static Message Create(FluxerBaseClient client, MessageJson json)
     {
-        var data = new Message(client);
+        Message data = new Message(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/OAuth/FluxerOAuthToken.cs
+++ b/Fluxer.Net/Data/OAuth/FluxerOAuthToken.cs
@@ -26,7 +26,7 @@ public class FluxerOAuthToken : Entity, IFluxerOAuthToken
 
     public static FluxerOAuthToken Create(FluxerBaseClient client, FluxerOAuthTokenJson json)
     {
-        var data = new FluxerOAuthToken(client);
+        FluxerOAuthToken data = new FluxerOAuthToken(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/OAuth/FluxerOAuthUser.cs
+++ b/Fluxer.Net/Data/OAuth/FluxerOAuthUser.cs
@@ -45,7 +45,7 @@ public class FluxerOAuthUser : User, IFluxerOAuthUser
 
     public static FluxerOAuthUser Create(FluxerBaseClient client, FluxerOAuthUserJson json)
     {
-        var data = new FluxerOAuthUser(client, null);
+        FluxerOAuthUser data = new FluxerOAuthUser(client, null);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/Activity.cs
+++ b/Fluxer.Net/Data/Users/Activity.cs
@@ -38,7 +38,7 @@ public class Activity : Entity, IActivity
 
     public static Activity Create(FluxerBaseClient client, ActivityJson json)
     {
-        var data = new Activity(client);
+        Activity data = new Activity(client);
         data.Update(client, json);
         return data;
     }
@@ -75,7 +75,7 @@ public class ActivityTimestamps : IActivityTimestamps
         if (json == null)
             return null;
 
-        var data = new ActivityTimestamps(client);
+        ActivityTimestamps data = new ActivityTimestamps(client);
         data.Update(client, json);
         return data;
     }
@@ -109,7 +109,7 @@ public class ActivityEmoji : IActivityEmoji
         if (json == null)
             return null;
 
-        var data = new ActivityEmoji(client);
+        ActivityEmoji data = new ActivityEmoji(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/ClientStatus.cs
+++ b/Fluxer.Net/Data/Users/ClientStatus.cs
@@ -22,7 +22,7 @@ public class ClientStatus : Entity, IClientStatus
         if (json == null)
             return null;
 
-        var data = new ClientStatus(client);
+        ClientStatus data = new ClientStatus(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/CurrentUser.cs
+++ b/Fluxer.Net/Data/Users/CurrentUser.cs
@@ -1,7 +1,7 @@
 ﻿namespace Fluxer.Net;
 
 /// <inheritdoc />
-public class CurrentUser : User, IUserProfile
+public class CurrentUser : User, ICurrentUser, IUserProfile
 {
     /// <inheritdoc />
     public bool IsStaff { get; internal set; }
@@ -69,70 +69,14 @@ public class CurrentUser : User, IUserProfile
     /// <inheritdoc />
     public HashSet<int>? AuthenticatorTypes { get; internal set; }
 
+    /// <inheritdoc />
+    public string? GetBannerUrl(int size = 600)
+    {
+        if (string.IsNullOrEmpty(BannerHash))
+            return null;
 
-
-    ///// <inheritdoc />
-    //public string? PasswordHash { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? TotpSecret { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? DateOfBirth { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? Locale { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? StripeSubscriptionId { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? StripeCustomerId { get; internal set; }
-
-    ///// <inheritdoc />
-    //public int SuspiciousActivityFlags { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? TermsAgreedAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? PrivacyAgreedAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? LastActiveAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? LastActiveIp { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? TempBannedUntil { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? PendingDeletionAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public int? DeletionReasonCode { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? DeletionPublicReason { get; internal set; }
-
-    ///// <inheritdoc />
-    //public string? DeletionAuditLogReason { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? FirstRefundAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public int BetaCodeAllowance { get; internal set; }
-
-    ///// <inheritdoc />
-    //public DateTime? BetaCodeLastResetAt { get; internal set; }
-
-    ///// <inheritdoc />
-    //public int? GiftInventoryServerSeq { get; internal set; }
-
-    ///// <inheritdoc />
-    //public int? GiftInventoryClientSeq { get; internal set; }
+        return $"{Client.Config.MediaUrl}/banners/{Id}/{BannerHash}.png?size={size}";
+    }
 
     internal CurrentUser(FluxerBaseClient client) : base(client)
     {
@@ -171,27 +115,5 @@ public class CurrentUser : User, IUserProfile
         HasEverPurchased = json.HasEverPurchased;
         EmailBounced = json.EmailBounced;
         AuthenticatorTypes = json.AuthenticatorTypes;
-
-        //PasswordHash = json.PasswordHash;
-        //TotpSecret = json.TotpSecret;
-        //DateOfBirth = json.DateOfBirth;
-        //Locale = json.Locale;
-        //StripeSubscriptionId = json.StripeSubscriptionId;
-        //StripeCustomerId = json.StripeCustomerId;
-        //SuspiciousActivityFlags = json.SuspiciousActivityFlags;
-        //TermsAgreedAt = json.TermsAgreedAt;
-        //PrivacyAgreedAt = json.PrivacyAgreedAt;
-        //LastActiveAt = json.LastActiveAt;
-        //LastActiveIp = json.LastActiveIp;
-        //TempBannedUntil = json.TempBannedUntil;
-        //PendingDeletionAt = json.PendingDeletionAt;
-        //DeletionReasonCode = json.DeletionReasonCode;
-        //DeletionPublicReason = json.DeletionPublicReason;
-        //DeletionAuditLogReason = json.DeletionAuditLogReason;
-        //FirstRefundAt = json.FirstRefundAt;
-        //BetaCodeAllowance = json.BetaCodeAllowance;
-        //BetaCodeLastResetAt = json.BetaCodeLastResetAt;
-        //GiftInventoryServerSeq = json.GiftInventoryServerSeq;
-        //GiftInventoryClientSeq = json.GiftInventoryClientSeq;
     }
 }

--- a/Fluxer.Net/Data/Users/CurrentUser.cs
+++ b/Fluxer.Net/Data/Users/CurrentUser.cs
@@ -141,7 +141,7 @@ public class CurrentUser : User, IUserProfile
 
     public static CurrentUser Create(FluxerBaseClient client, CurrentUserJson json)
     {
-        var data = new CurrentUser(client);
+        CurrentUser data = new CurrentUser(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/CurrentUserJson.cs
+++ b/Fluxer.Net/Data/Users/CurrentUserJson.cs
@@ -93,89 +93,12 @@ public class CurrentUserJson : UserJson, IUserProfile
     [JsonProperty("authenticator_types")]
     public HashSet<int>? AuthenticatorTypes { get; set; }
 
+    /// <inheritdoc />
+    public string? GetBannerUrl(int size = 600)
+    {
+        if (string.IsNullOrEmpty(BannerHash))
+            return null;
 
-
-    ///// <inheritdoc />
-    //[JsonProperty("password_hash")]
-    //public string? PasswordHash { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("totp_secret")]
-    //public string? TotpSecret { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("date_of_birth")]
-    //public string? DateOfBirth { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("locale")]
-    //public string? Locale { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("stripe_subscription_id")]
-    //public string? StripeSubscriptionId { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("stripe_customer_id")]
-    //public string? StripeCustomerId { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("suspicious_activity_flags")]
-    //public int SuspiciousActivityFlags { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("terms_agreed_at")]
-    //public DateTime? TermsAgreedAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("privacy_agreed_at")]
-    //public DateTime? PrivacyAgreedAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("last_active_at")]
-    //public DateTime? LastActiveAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("last_active_ip")]
-    //public string? LastActiveIp { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("temp_banned_until")]
-    //public DateTime? TempBannedUntil { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("pending_deletion_at")]
-    //public DateTime? PendingDeletionAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("deletion_reason_code")]
-    //public int? DeletionReasonCode { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("deletion_public_reason")]
-    //public string? DeletionPublicReason { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("deletion_audit_log_reason")]
-    //public string? DeletionAuditLogReason { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("first_refund_at")]
-    //public DateTime? FirstRefundAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("beta_code_allowance")]
-    //public int BetaCodeAllowance { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("beta_code_last_reset_at")]
-    //public DateTime? BetaCodeLastResetAt { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("gift_inventory_server_seq")]
-    //public int? GiftInventoryServerSeq { get; set; }
-
-    ///// <inheritdoc />
-    //[JsonProperty("gift_inventory_client_seq")]
-    //public int? GiftInventoryClientSeq { get; set; }
+        return $"https://fluxerusercontent.com/banners/{Id}/{BannerHash}.png?size={size}";
+    }
 }

--- a/Fluxer.Net/Data/Users/ICurrentUser.cs
+++ b/Fluxer.Net/Data/Users/ICurrentUser.cs
@@ -92,50 +92,8 @@ public interface ICurrentUser : IUser
     /// </summary>
     HashSet<int>? AuthenticatorTypes { get; }
 
-
-    //
-    // Old properties???
-    //
-
-    //string? PasswordHash { get; }
-
-    //string? TotpSecret { get; }
-
-    //string? DateOfBirth { get; }
-
-    //string? Locale { get; }
-
-    //string? StripeSubscriptionId { get; }
-
-    //string? StripeCustomerId { get; }
-
-    //int SuspiciousActivityFlags { get; }
-
-    //DateTime? TermsAgreedAt { get; }
-
-    //DateTime? PrivacyAgreedAt { get; }
-
-    //DateTime? LastActiveAt { get; }
-
-    //string? LastActiveIp { get; }
-
-    //DateTime? TempBannedUntil { get; }
-
-    //DateTime? PendingDeletionAt { get; }
-
-    //int? DeletionReasonCode { get; }
-
-    //string? DeletionPublicReason { get; }
-
-    //string? DeletionAuditLogReason { get; }
-
-    //DateTime? FirstRefundAt { get; }
-
-    //int BetaCodeAllowance { get; }
-
-    //DateTime? BetaCodeLastResetAt { get; }
-
-    //int? GiftInventoryServerSeq { get; }
-
-    //int? GiftInventoryClientSeq { get; }
+    /// <summary>
+    /// Get the user's banner.
+    /// </summary>
+    string? GetBannerUrl(int size);
 }

--- a/Fluxer.Net/Data/Users/IUser.cs
+++ b/Fluxer.Net/Data/Users/IUser.cs
@@ -8,6 +8,11 @@ public interface IUser
     ulong Id { get; }
 
     /// <summary>
+    /// Get the mention for the user.
+    /// </summary>
+    string Mention { get; }
+
+    /// <summary>
     /// The username of the user, not unique across the platform.
     /// </summary>
     string Username { get; }

--- a/Fluxer.Net/Data/Users/IUser.cs
+++ b/Fluxer.Net/Data/Users/IUser.cs
@@ -56,4 +56,14 @@ public interface IUser
     /// Get the default avatar for the user.
     /// </summary>
     string GetDefaultAvatarUrl();
+
+    /// <summary>
+    /// Get the user's avatar.
+    /// </summary>
+    string? GetAvatarUrl(int size);
+
+    /// <summary>
+    /// Get the user's avatar or fallback to default.
+    /// </summary>
+    string GetAvatarOrDefaultUrl(int size);
 }

--- a/Fluxer.Net/Data/Users/IUser.cs
+++ b/Fluxer.Net/Data/Users/IUser.cs
@@ -53,6 +53,11 @@ public interface IUser
     bool IsSystem { get; }
 
     /// <summary>
+    /// Get the user's current display name or username.
+    /// </summary>
+    string GetCurrentName();
+
+    /// <summary>
     /// Get the default avatar for the user.
     /// </summary>
     string GetDefaultAvatarUrl();

--- a/Fluxer.Net/Data/Users/IUser.cs
+++ b/Fluxer.Net/Data/Users/IUser.cs
@@ -51,4 +51,9 @@ public interface IUser
     /// Whether the user is an official system user.
     /// </summary>
     bool IsSystem { get; }
+
+    /// <summary>
+    /// Get the default avatar for the user.
+    /// </summary>
+    string GetDefaultAvatarUrl();
 }

--- a/Fluxer.Net/Data/Users/Presence.cs
+++ b/Fluxer.Net/Data/Users/Presence.cs
@@ -29,7 +29,7 @@ public class Presence : Entity, IPresence
 
     public static Presence Create(FluxerBaseClient client, PresenceJson json)
     {
-        var data = new Presence(client);
+        Presence data = new Presence(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/User.cs
+++ b/Fluxer.Net/Data/Users/User.cs
@@ -34,6 +34,12 @@ public class User : Entity, IUser
     public bool IsSystem { get; internal set; }
 
     /// <inheritdoc />
+    public string GetCurrentName()
+    {
+        return DisplayName ?? Username;
+    }
+
+    /// <inheritdoc />
     public string GetDefaultAvatarUrl()
     {
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";

--- a/Fluxer.Net/Data/Users/User.cs
+++ b/Fluxer.Net/Data/Users/User.cs
@@ -39,6 +39,24 @@ public class User : Entity, IUser
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
     }
 
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return null;
+
+        return $"{Client.Config.MediaUrl}/avatars/{Id}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
+
     internal User(FluxerBaseClient client) : base(client)
     {
 

--- a/Fluxer.Net/Data/Users/User.cs
+++ b/Fluxer.Net/Data/Users/User.cs
@@ -7,6 +7,9 @@ public class User : Entity, IUser
     public ulong Id { get; internal set; }
 
     /// <inheritdoc />
+    public string Mention => $"<@{Id}>";
+
+    /// <inheritdoc />
     public string Username { get; internal set; }
 
     /// <inheritdoc />

--- a/Fluxer.Net/Data/Users/User.cs
+++ b/Fluxer.Net/Data/Users/User.cs
@@ -33,6 +33,12 @@ public class User : Entity, IUser
     /// <inheritdoc />
     public bool IsSystem { get; internal set; }
 
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
+    }
+
     internal User(FluxerBaseClient client) : base(client)
     {
 

--- a/Fluxer.Net/Data/Users/User.cs
+++ b/Fluxer.Net/Data/Users/User.cs
@@ -37,7 +37,7 @@ public class User : Entity, IUser
 
     public static User Create(FluxerBaseClient client, UserJson json)
     {
-        var data = new User(client);
+        User data = new User(client);
         data.Update(json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/UserConnection.cs
+++ b/Fluxer.Net/Data/Users/UserConnection.cs
@@ -28,7 +28,7 @@ public class UserConnection : Entity, IUserConnection
 
     public static UserConnection Create(FluxerBaseClient client, UserConnectionJson json)
     {
-        var data = new UserConnection(client);
+        UserConnection data = new UserConnection(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/UserJson.cs
+++ b/Fluxer.Net/Data/Users/UserJson.cs
@@ -10,6 +10,10 @@ public class UserJson : IUser
     public ulong Id { get; set; }
 
     /// <inheritdoc />
+    [JsonIgnore]
+    public string Mention => $"<@{Id}>";
+
+    /// <inheritdoc />
     [JsonProperty("username")]
     public string Username { get; set; }
 

--- a/Fluxer.Net/Data/Users/UserJson.cs
+++ b/Fluxer.Net/Data/Users/UserJson.cs
@@ -50,4 +50,22 @@ public class UserJson : IUser
     {
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
     }
+
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return null;
+
+        return $"https://fluxerusercontent.com/avatars/{Id}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
 }

--- a/Fluxer.Net/Data/Users/UserJson.cs
+++ b/Fluxer.Net/Data/Users/UserJson.cs
@@ -46,6 +46,12 @@ public class UserJson : IUser
     public bool IsSystem { get; set; }
 
     /// <inheritdoc />
+    public string GetCurrentName()
+    {
+        return DisplayName ?? Username;
+    }
+
+    /// <inheritdoc />
     public string GetDefaultAvatarUrl()
     {
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";

--- a/Fluxer.Net/Data/Users/UserJson.cs
+++ b/Fluxer.Net/Data/Users/UserJson.cs
@@ -44,4 +44,10 @@ public class UserJson : IUser
     /// <inheritdoc />
     [JsonProperty("system")]
     public bool IsSystem { get; set; }
+
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
+    }
 }

--- a/Fluxer.Net/Data/Users/UserProfile.cs
+++ b/Fluxer.Net/Data/Users/UserProfile.cs
@@ -3,6 +3,11 @@
 /// <inheritdoc />
 public class UserProfile : Entity, IUserProfile
 {
+    /// <summary>
+    /// User's id for the profile.
+    /// </summary>
+    public ulong UserId { get; internal set; }
+
     /// <inheritdoc />
     public string? Bio { get; internal set; }
 
@@ -18,14 +23,26 @@ public class UserProfile : Entity, IUserProfile
     /// <inheritdoc />
     public int? BannerColor { get; internal set; }
 
+    /// <summary>
+    /// Get the user's banner.
+    /// </summary>
+    public string? GetBannerUrl(int size = 600)
+    {
+        if (string.IsNullOrEmpty(BannerHash))
+            return null;
+
+        return $"{Client.Config.MediaUrl}/banners/{UserId}/{BannerHash}.png?size={size}";
+    }
+
     internal UserProfile(FluxerBaseClient client) : base(client)
     {
 
     }
 
-    public static UserProfile Create(FluxerBaseClient client, UserProfileJson json)
+    public static UserProfile Create(FluxerBaseClient client, UserProfileJson json, ulong userId)
     {
         UserProfile data = new UserProfile(client);
+        data.UserId = userId;
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/UserProfile.cs
+++ b/Fluxer.Net/Data/Users/UserProfile.cs
@@ -25,7 +25,7 @@ public class UserProfile : Entity, IUserProfile
 
     public static UserProfile Create(FluxerBaseClient client, UserProfileJson json)
     {
-        var data = new UserProfile(client);
+        UserProfile data = new UserProfile(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Users/UserSettings.cs
+++ b/Fluxer.Net/Data/Users/UserSettings.cs
@@ -85,7 +85,7 @@ public class UserSettings : Entity, IUserSettings
 
     public static UserSettings Create(FluxerBaseClient client, UserSettingsJson json)
     {
-        var data = new UserSettings(client);
+        UserSettings data = new UserSettings(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Voice/CallEligibility.cs
+++ b/Fluxer.Net/Data/Voice/CallEligibility.cs
@@ -18,7 +18,7 @@ public class CallEligibility : Entity, ICallEligibility
 
     public static CallEligibility Create(FluxerBaseClient client, CallEligibilityJson json)
     {
-        var data = new CallEligibility(client);
+        CallEligibility data = new CallEligibility(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Voice/RtcRegion.cs
+++ b/Fluxer.Net/Data/Voice/RtcRegion.cs
@@ -19,7 +19,7 @@ public class RtcRegion : Entity, IRtcRegion
 
     public static RtcRegion Create(FluxerBaseClient client, RtcRegionJson json)
     {
-        var data = new RtcRegion(client);
+        RtcRegion data = new RtcRegion(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Webhooks/IWebhook.cs
+++ b/Fluxer.Net/Data/Webhooks/IWebhook.cs
@@ -44,4 +44,14 @@ public interface IWebhook
     /// Get the default avatar for the user.
     /// </summary>
     string GetDefaultAvatarUrl();
+
+    /// <summary>
+    /// Get the webhooks's avatar.
+    /// </summary>
+    string? GetAvatarUrl(int size);
+
+    /// <summary>
+    /// Get the webhooks's avatar or fallback to default.
+    /// </summary>
+    string GetAvatarOrDefaultUrl(int size);
 }

--- a/Fluxer.Net/Data/Webhooks/IWebhook.cs
+++ b/Fluxer.Net/Data/Webhooks/IWebhook.cs
@@ -39,4 +39,9 @@ public interface IWebhook
     /// The hash of the webhook avatar image.
     /// </summary>
     string? AvatarHash { get; }
+
+    /// <summary>
+    /// Get the default avatar for the user.
+    /// </summary>
+    string GetDefaultAvatarUrl();
 }

--- a/Fluxer.Net/Data/Webhooks/Webhook.cs
+++ b/Fluxer.Net/Data/Webhooks/Webhook.cs
@@ -31,7 +31,7 @@ public class Webhook : Entity, IWebhook
 
     public static Webhook Create(FluxerBaseClient client, WebhookJson json)
     {
-        var data = new Webhook(client);
+        Webhook data = new Webhook(client);
         data.Update(client, json);
         return data;
     }

--- a/Fluxer.Net/Data/Webhooks/Webhook.cs
+++ b/Fluxer.Net/Data/Webhooks/Webhook.cs
@@ -24,6 +24,12 @@ public class Webhook : Entity, IWebhook
     /// <inheritdoc />
     public string? AvatarHash { get; internal set; }
 
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
+    }
+
     internal Webhook(FluxerBaseClient client) : base(client)
     {
 

--- a/Fluxer.Net/Data/Webhooks/Webhook.cs
+++ b/Fluxer.Net/Data/Webhooks/Webhook.cs
@@ -30,6 +30,24 @@ public class Webhook : Entity, IWebhook
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
     }
 
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return null;
+
+        return $"{Client.Config.MediaUrl}/avatars/{Id}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
+
     internal Webhook(FluxerBaseClient client) : base(client)
     {
 

--- a/Fluxer.Net/Data/Webhooks/WebhookJson.cs
+++ b/Fluxer.Net/Data/Webhooks/WebhookJson.cs
@@ -38,4 +38,22 @@ public class WebhookJson : IWebhook
     {
         return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
     }
+
+    /// <inheritdoc />
+    public string? GetAvatarUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return null;
+
+        return $"https://fluxerusercontent.com/avatars/{Id}/{AvatarHash}.png?size={size}";
+    }
+
+    /// <inheritdoc />
+    public string GetAvatarOrDefaultUrl(int size = 160)
+    {
+        if (string.IsNullOrEmpty(AvatarHash))
+            return GetDefaultAvatarUrl();
+
+        return GetAvatarUrl(size);
+    }
 }

--- a/Fluxer.Net/Data/Webhooks/WebhookJson.cs
+++ b/Fluxer.Net/Data/Webhooks/WebhookJson.cs
@@ -32,4 +32,10 @@ public class WebhookJson : IWebhook
     /// <inheritdoc />
     [JsonProperty("avatar")]
     public string? AvatarHash { get; set; }
+
+    /// <inheritdoc />
+    public string GetDefaultAvatarUrl()
+    {
+        return $"https://fluxerstatic.com/avatars/{Id % 6}.png";
+    }
 }

--- a/Fluxer.Net/FluxerClient.cs
+++ b/Fluxer.Net/FluxerClient.cs
@@ -8,6 +8,7 @@ public abstract class FluxerBaseClient
     internal ulong Id { get; set; }
     internal string Token { get; set; }
     internal ApiClient Rest { get; set; }
+    public FluxerConfig Config { get; internal set; }
 }
 
 /// <summary>
@@ -47,8 +48,6 @@ public class FluxerClient : FluxerBaseClient
     }
 
     public new string Token => base.Token;
-
-    public FluxerConfig Config { get; }
 
     /// <summary>
     /// Returns the raw token without any "Bot " prefix, for use in gateway IDENTIFY/RESUME packets.

--- a/Fluxer.Net/FluxerConfig.cs
+++ b/Fluxer.Net/FluxerConfig.cs
@@ -76,4 +76,9 @@ public class FluxerConfig
     /// This is the actual URL used for API requests.
     /// </summary>
     public string RealApiBaseUrl { get => FluxerApiBaseUrl.Replace("{v}", Version.ToString()); }
+
+    /// <summary>
+    /// Get the media/user content url.
+    /// </summary>
+    public string MediaUrl { get; set; } = "https://fluxerusercontent.com";
 }

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -858,6 +858,9 @@
         <member name="P:Fluxer.Net.Channel.Id">
             <inheritdoc />
         </member>
+        <member name="P:Fluxer.Net.Channel.Mention">
+            <inheritdoc />
+        </member>
         <member name="P:Fluxer.Net.Channel.GuildId">
             <inheritdoc />
         </member>
@@ -928,6 +931,9 @@
             </remarks>
         </member>
         <member name="P:Fluxer.Net.ChannelJson.Id">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.ChannelJson.Mention">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.ChannelJson.GuildId">
@@ -1123,6 +1129,11 @@
         <member name="P:Fluxer.Net.IChannel.Id">
             <summary>
             The unique identifier (snowflake) for this channel.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IChannel.Mention">
+            <summary>
+            Get the mention for this channel.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IChannel.GuildId">
@@ -2776,6 +2787,12 @@
         <member name="T:Fluxer.Net.GuildMember">
             <inheritdoc />
         </member>
+        <member name="P:Fluxer.Net.GuildMember.UserId">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.GuildMember.Mention">
+            <inheritdoc />
+        </member>
         <member name="P:Fluxer.Net.GuildMember.GuildId">
             <inheritdoc />
         </member>
@@ -2831,6 +2848,12 @@
             <inheritdoc />
         </member>
         <member name="T:Fluxer.Net.GuildMemberJson">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.GuildMemberJson.UserId">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.GuildMemberJson.Mention">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.GuildMemberJson.GuildId">
@@ -2907,9 +2930,24 @@
             Ban Reason (max 512 characters)
             </summary>
         </member>
+        <member name="P:Fluxer.Net.IGuildMember.UserId">
+            <summary>
+            User id for this member.
+            </summary>
+        </member>
         <member name="P:Fluxer.Net.IGuildMember.GuildId">
             <summary>
             Guild id that the user is in.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IGuildMember.Mention">
+            <summary>
+            Get the mention for the user.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IGuildMember.User">
+            <summary>
+            User data for the member.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IGuildMember.JoinedAt">
@@ -2960,6 +2998,11 @@
         <member name="P:Fluxer.Net.IRole.Id">
             <summary>
             The unique identifier for this role.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IRole.Mention">
+            <summary>
+            Get the mention for this role.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IRole.Name">
@@ -3031,6 +3074,9 @@
         <member name="P:Fluxer.Net.Role.Id">
             <inheritdoc />
         </member>
+        <member name="P:Fluxer.Net.Role.Mention">
+            <inheritdoc />
+        </member>
         <member name="P:Fluxer.Net.Role.Name">
             <inheritdoc />
         </member>
@@ -3056,6 +3102,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.RoleJson.Id">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.RoleJson.Mention">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.RoleJson.Name">
@@ -3639,6 +3688,16 @@
         <member name="P:Fluxer.Net.IGuildVanityUrl.Uses">
             <summary>
             The number of times this vanity URL has been used.
+            </summary>
+        </member>
+        <member name="T:Fluxer.Net.SocketGuild">
+            <summary>
+            Cached guild from the gateway.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.SocketGuild.CurrentMember">
+            <summary>
+            Cached current logged in member for the guild.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IInvite.CreatedAt">
@@ -4810,6 +4869,11 @@
             The unique identifier (snowflake) for this user.
             </summary>
         </member>
+        <member name="P:Fluxer.Net.IUser.Mention">
+            <summary>
+            Get the mention for the user.
+            </summary>
+        </member>
         <member name="P:Fluxer.Net.IUser.Username">
             <summary>
             The username of the user, not unique across the platform.
@@ -5000,6 +5064,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.User.Id">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.User.Mention">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.User.Username">
@@ -5266,6 +5333,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.UserJson.Id">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.UserJson.Mention">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.UserJson.Username">
@@ -5888,11 +5958,6 @@
         <member name="T:Fluxer.Net.Gateway.Data.Guilds.GuildMemberGatewayData">
             <summary>
             Gateway guild member data matching the GuildMemberResponse API model
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.Gateway.Data.Guilds.GuildMemberGatewayData.GuildId">
-            <summary>
-            Guild ID for context (added for gateway events)
             </summary>
         </member>
         <member name="T:Fluxer.Net.Gateway.Data.Guilds.GuildRoleDeleteGatewayData">

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -5821,11 +5821,6 @@
             Gateway data for GUILD_EMOJIS_UPDATE event when guild emojis are updated.
             </summary>
         </member>
-        <member name="T:Fluxer.Net.Gateway.Data.Guilds.GuildCreateProperties">
-            <summary>
-            The nested guild properties object sent inside a GUILD_CREATE payload.
-            </summary>
-        </member>
         <member name="T:Fluxer.Net.Gateway.Data.Guilds.GuildGatewayData">
             <summary>
             Gateway data for GUILD_CREATE and GUILD_UPDATE events.
@@ -7058,6 +7053,51 @@
             Occurs when an invite is deleted or expires.
             </summary>
         </member>
+        <member name="T:Fluxer.Net.OAuth.FluxerOAuthExtensions">
+            <Summary>
+            Extension methods for handling fluxer oauth client.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxerClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,System.String,Fluxer.Net.FluxerConfig)">
+            <Summary>
+            Add Fluxer oauth client on dependency injection service.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.GetFluxerClaims(System.Security.Claims.ClaimsPrincipal,Fluxer.Net.FluxerBaseClient)">
+            <Summary>
+            Get Fluxer specific claims for a claim user.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder)">
+            <Summary>
+            Add Fluxer oauth client on dependency injection service.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
+            <Summary>
+            Add Fluxer oauth client on dependency injection service.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
+            <Summary>
+            Add Fluxer oauth client on dependency injection service.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
+            <Summary>
+            Add Fluxer oauth client on dependency injection service.
+            </Summary>
+        </member>
+        <member name="T:Fluxer.Net.OAuth.FluxerOAuthHandler">
+            <Summary>
+            Asp.net oauth handler for Fluxer.
+            </Summary>
+        </member>
+        <member name="M:Fluxer.Net.OAuth.FluxerOAuthHandler.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Fluxer.Net.OAuth.FluxerOAuthOptions},Microsoft.Extensions.Logging.ILoggerFactory,System.Text.Encodings.Web.UrlEncoder,Microsoft.AspNetCore.Authentication.ISystemClock)">
+            <Summary>
+            Create asp.net oauth handler for Fluxer.
+            </Summary>
+        </member>
         <member name="T:Fluxer.Net.RateLimiting.RateLimitBucket">
             <summary>
             Represents a sliding window rate limit bucket for API requests
@@ -7772,69 +7812,6 @@
             </summary>
         </member>
         <member name="P:Fluxer.Net.MessageSearchRequest.ExcludeAttachmentExtensions">
-            <summary>
-            File extensions to exclude
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.MessageSearchRequest.SortBy">
-            <summary>
-            Field to sort results by
-            </summary>
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L134"/>
-            </remarks>
-        </member>
-        <member name="P:Fluxer.Net.MessageSearchRequest.SortOrder">
-            <summary>
-            Sort order for results
-            </summary>
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L147"/>
-            </remarks>
-        </member>
-        <member name="P:Fluxer.Net.MessageSearchRequest.IncludeNsfw">
-            <summary>
-            Whether to include NSFW channel results
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.MessageSearchRequest.MessageSearchScope">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L160"/>
-            </remarks>
-        </member>
-        <member name="T:Fluxer.Net.UpdateMessageRequest">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/api/src/channel/MessageTypes.tsx#L32"/>
-            </remarks>
-        </member>
-        <member name="P:Fluxer.Net.UpdateMessageRequest.Content">
-            <summary>
-            The message content (up to 2000 characters)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.UpdateMessageRequest.Embeds">
-            <summary>
-            Array of embed objects to include in the message
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.UpdateMessageRequest.AllowedMentions">
-            <summary>
-            Controls which mentions trigger notifications
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.UpdateMessageRequest.Flags">
-            <summary>
-            Message flags bitfield
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.UpdateMessageRequest.Attachments">
-            <summary>
-            Array of attachment objects to keep or add
-            </summary>
-        </member>
-    </members>
-</doc>
-ions">
             <summary>
             File extensions to exclude
             </summary>

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -2847,6 +2847,18 @@
         <member name="P:Fluxer.Net.GuildMember.IsTemporary">
             <inheritdoc />
         </member>
+        <member name="M:Fluxer.Net.GuildMember.GetCurrentName">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMember.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMember.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMember.GetAvatarOrDefaultUrl(System.Int32)">
+            <inheritdoc />
+        </member>
         <member name="T:Fluxer.Net.GuildMemberJson">
             <inheritdoc />
         </member>
@@ -2908,6 +2920,18 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.GuildMemberJson.IsTemporary">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMemberJson.GetCurrentName">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMemberJson.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMemberJson.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.GuildMemberJson.GetAvatarOrDefaultUrl(System.Int32)">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.IGuildBan.BannedAt">
@@ -2993,6 +3017,26 @@
         <member name="P:Fluxer.Net.IGuildMember.RoleIds">
             <summary>
             Array of role IDs the member has.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IGuildMember.GetCurrentName">
+            <summary>
+            Get the members's current nickname, display name or username.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IGuildMember.GetDefaultAvatarUrl">
+            <summary>
+            Get the default avatar for the user.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IGuildMember.GetAvatarUrl(System.Int32)">
+            <summary>
+            Get the members's avatar.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IGuildMember.GetAvatarOrDefaultUrl(System.Int32)">
+            <summary>
+            Get the members's avatar or fallback to default.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IRole.Id">
@@ -4690,6 +4734,9 @@
         <member name="P:Fluxer.Net.CurrentUser.AuthenticatorTypes">
             <inheritdoc />
         </member>
+        <member name="M:Fluxer.Net.CurrentUser.GetBannerUrl(System.Int32)">
+            <inheritdoc />
+        </member>
         <member name="T:Fluxer.Net.CurrentUserJson">
             <inheritdoc />
         </member>
@@ -4757,6 +4804,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.CurrentUserJson.AuthenticatorTypes">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.CurrentUserJson.GetBannerUrl(System.Int32)">
             <inheritdoc />
         </member>
         <member name="T:Fluxer.Net.FriendSourceFlags">
@@ -4864,6 +4914,11 @@
             The types of authenticators configured for MFA.
             </summary>
         </member>
+        <member name="M:Fluxer.Net.ICurrentUser.GetBannerUrl(System.Int32)">
+            <summary>
+            Get the user's banner.
+            </summary>
+        </member>
         <member name="P:Fluxer.Net.IUser.Id">
             <summary>
             The unique identifier (snowflake) for this user.
@@ -4912,6 +4967,26 @@
         <member name="P:Fluxer.Net.IUser.IsSystem">
             <summary>
             Whether the user is an official system user.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IUser.GetCurrentName">
+            <summary>
+            Get the user's current display name or username.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IUser.GetDefaultAvatarUrl">
+            <summary>
+            Get the default avatar for the user.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IUser.GetAvatarUrl(System.Int32)">
+            <summary>
+            Get the user's avatar.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IUser.GetAvatarOrDefaultUrl(System.Int32)">
+            <summary>
+            Get the user's avatar or fallback to default.
             </summary>
         </member>
         <member name="P:Fluxer.Net.IUserConnection.Id">
@@ -5091,6 +5166,18 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.User.IsSystem">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.User.GetCurrentName">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.User.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.User.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.User.GetAvatarOrDefaultUrl(System.Int32)">
             <inheritdoc />
         </member>
         <member name="T:Fluxer.Net.UserConnection">
@@ -5362,8 +5449,25 @@
         <member name="P:Fluxer.Net.UserJson.IsSystem">
             <inheritdoc />
         </member>
+        <member name="M:Fluxer.Net.UserJson.GetCurrentName">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.UserJson.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.UserJson.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.UserJson.GetAvatarOrDefaultUrl(System.Int32)">
+            <inheritdoc />
+        </member>
         <member name="T:Fluxer.Net.UserProfile">
             <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.UserProfile.UserId">
+            <summary>
+            User's id for the profile.
+            </summary>
         </member>
         <member name="P:Fluxer.Net.UserProfile.Bio">
             <inheritdoc />
@@ -5379,6 +5483,11 @@
         </member>
         <member name="P:Fluxer.Net.UserProfile.BannerColor">
             <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.UserProfile.GetBannerUrl(System.Int32)">
+            <summary>
+            Get the user's banner.
+            </summary>
         </member>
         <member name="T:Fluxer.Net.UserProfileJson">
             <inheritdoc />
@@ -5667,6 +5776,21 @@
             The hash of the webhook avatar image.
             </summary>
         </member>
+        <member name="M:Fluxer.Net.IWebhook.GetDefaultAvatarUrl">
+            <summary>
+            Get the default avatar for the user.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IWebhook.GetAvatarUrl(System.Int32)">
+            <summary>
+            Get the webhooks's avatar.
+            </summary>
+        </member>
+        <member name="M:Fluxer.Net.IWebhook.GetAvatarOrDefaultUrl(System.Int32)">
+            <summary>
+            Get the webhooks's avatar or fallback to default.
+            </summary>
+        </member>
         <member name="T:Fluxer.Net.Webhook">
             <inheritdoc />
         </member>
@@ -5691,6 +5815,15 @@
         <member name="P:Fluxer.Net.Webhook.AvatarHash">
             <inheritdoc />
         </member>
+        <member name="M:Fluxer.Net.Webhook.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.Webhook.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.Webhook.GetAvatarOrDefaultUrl(System.Int32)">
+            <inheritdoc />
+        </member>
         <member name="T:Fluxer.Net.WebhookJson">
             <inheritdoc />
         </member>
@@ -5713,6 +5846,15 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.WebhookJson.AvatarHash">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.WebhookJson.GetDefaultAvatarUrl">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.WebhookJson.GetAvatarUrl(System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.WebhookJson.GetAvatarOrDefaultUrl(System.Int32)">
             <inheritdoc />
         </member>
         <member name="T:Fluxer.Net.WebhookType">
@@ -5822,6 +5964,11 @@
             <summary>
             Gets the fully resolved API base URL with the version number substituted.
             This is the actual URL used for API requests.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.FluxerConfig.MediaUrl">
+            <summary>
+            Get the media/user content url.
             </summary>
         </member>
         <member name="T:Fluxer.Net.Gateway.Data.Auth.AuthSessionChangeGatewayData">

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -2997,6 +2997,31 @@
             Whether this role can be mentioned by anyone.
             </summary>
         </member>
+        <member name="F:Fluxer.Net.JoinSource.Creator">
+            <summary>
+            User created the guild.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.JoinSource.Invite">
+            <summary>
+            User joined by invite.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.JoinSource.VanityUrl">
+            <summary>
+            User joined by vanity url.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.JoinSource.BotInvite">
+            <summary>
+            Bot was manually added.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.JoinSource.AdminForceAdd">
+            <summary>
+            User was force joined by admin.
+            </summary>
+        </member>
         <member name="T:Fluxer.Net.Role">
             <inheritdoc />
         </member>
@@ -3058,6 +3083,51 @@
             <summary>
             Currently only used when updating role positions in <see cref="!:ApiClient.UpdateRolePositions"/>
             </summary>
+        </member>
+        <member name="T:Fluxer.Net.PartialGuild">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.Id">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.Name">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.IconHash">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.BannerHash">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.BannerWidth">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.BannerHeight">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.EmbedSplashHash">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.EmbedSplashWidth">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.EmbedSplashHeight">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.SplashHash">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.SplashWidth">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.SplashHeight">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.SplashCardAligment">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.PartialGuild.Features">
+            <inheritdoc />
         </member>
         <member name="T:Fluxer.Net.PartialGuildJson">
             <inheritdoc />
@@ -3461,6 +3531,46 @@
         <member name="F:Fluxer.Net.GuildNsfwLevel.AgeRestricted">
             <summary>
             Users in certain countries will need to be age verified.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.None">
+            <summary>
+            No flags set.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.PushNotifications">
+            <summary>
+            Push notifications for this guild.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.EveryoneMentions">
+            <summary>
+            @everyone mentions in this guild.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.TypingEvents">
+            <summary>
+            Typing indicator events.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.InstantInvites">
+            <summary>
+            Creation of instant invites.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.SendMessages">
+            <summary>
+            Sending messages in the guild.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.Reactions">
+            <summary>
+            Adding reactions to messages.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.GuildOperations.MemberListUpdates">
+            <summary>
+            Member list update events.
             </summary>
         </member>
         <member name="T:Fluxer.Net.GuildSplashCardAlignment">
@@ -4109,6 +4219,11 @@
             Message is a voice attachment.
             </summary>
         </member>
+        <member name="F:Fluxer.Net.MessageFlag.CompactAttachments">
+            <summary>
+            Display attachments in a compact format.
+            </summary>
+        </member>
         <member name="T:Fluxer.Net.MessageJson">
             <inheritdoc />
             <remarks>
@@ -4274,6 +4389,69 @@
         <member name="F:Fluxer.Net.MessageType.Reply">
             <summary>
             A message that is a reply to another message.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.MessageType.SystemMessage">
+            <summary>
+            System message.
+            </summary>
+        </member>
+        <member name="T:Fluxer.Net.FluxerOAuthToken">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthToken.Application">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthToken.Scopes">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthToken.Expires">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthToken.User">
+            <inheritdoc />
+        </member>
+        <member name="T:Fluxer.Net.FluxerOAuthTokenJson">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthTokenJson.Application">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthTokenJson.Scopes">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthTokenJson.Expires">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthTokenJson.User">
+            <inheritdoc />
+        </member>
+        <member name="T:Fluxer.Net.FluxerOAuthUser">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthUser.Email">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthUser.IsVerified">
+            <inheritdoc />
+        </member>
+        <member name="T:Fluxer.Net.FluxerOAuthUserJson">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthUserJson.Email">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.FluxerOAuthUserJson.IsVerified">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.IFluxerOAuthUser.Email">
+            <summary>
+            The email address of the user.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IFluxerOAuthUser.IsVerified">
+            <summary>
+            Whether the user has verified their email.
             </summary>
         </member>
         <member name="T:Fluxer.Net.Activity">
@@ -4944,6 +5122,16 @@
             Bug hunter badge (found and reported bugs).
             </summary>
         </member>
+        <member name="F:Fluxer.Net.UserFlags.FriendlyBot">
+            <summary>
+            Bot accepts friend requests from users.
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.FriendlyBotManualApproval">
+            <summary>
+            Bot requires manual approval for friend requests.
+            </summary>
+        </member>
         <member name="F:Fluxer.Net.UserFlags.HighGlobalRateLimit">
             <summary>
             User has a higher global rate limit (internal flag).
@@ -5037,6 +5225,41 @@
         <member name="F:Fluxer.Net.UserFlags.HasDismissedPremiumOnboarding">
             <summary>
             User has dismissed the premium onboarding flow (user preference).
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.UsedMobileClient">
+            <summary>
+            User has used a mobile client (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.AppStoreReviewer">
+            <summary>
+            User is an app store reviewer (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.DmHistoryBackfilled">
+            <summary>
+            User DM history has been backfilled (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.HasRelationshipsIndexed">
+            <summary>
+            User relationships have been indexed (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.MessagesByAuthorBackfilled">
+            <summary>
+            Messages by this author have been backfilled (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.StaffHidden">
+            <summary>
+            User staff status is hidden from public flags (internal flag)
+            </summary>
+        </member>
+        <member name="F:Fluxer.Net.UserFlags.BotSanitized">
+            <summary>
+            User's owned bot discriminators have been sanitized (internal flag)
             </summary>
         </member>
         <member name="T:Fluxer.Net.UserJson">
@@ -5261,17 +5484,30 @@
         <member name="P:Fluxer.Net.UserSettingsJson.TimeFormat">
             <inheritdoc />
         </member>
-        <member name="T:Fluxer.Net.CallEligibilityJson">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/schema/src/domains/channel/ChannelSchemas.tsx#L44"/>
-            </remarks>
+        <member name="T:Fluxer.Net.CallEligibility">
+            <inheritdoc />
         </member>
-        <member name="P:Fluxer.Net.CallEligibilityJson.Ringable">
+        <member name="P:Fluxer.Net.CallEligibility.IsRingable">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.CallEligibility.IsSilent">
+            <inheritdoc />
+        </member>
+        <member name="T:Fluxer.Net.CallEligibilityJson">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.CallEligibilityJson.IsRingable">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.CallEligibilityJson.IsSilent">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.ICallEligibility.IsRingable">
             <summary>
             Whether the current user can ring this call
             </summary>
         </member>
-        <member name="P:Fluxer.Net.CallEligibilityJson.Silent">
+        <member name="P:Fluxer.Net.ICallEligibility.IsSilent">
             <summary>
             Whether the call should be joined silently
             </summary>
@@ -6822,79 +7058,6 @@
             Occurs when an invite is deleted or expires.
             </summary>
         </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthExtensions">
-            <Summary>
-            Extension methods for handling fluxer oauth client.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxerClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,System.String,Fluxer.Net.FluxerConfig)">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.GetFluxerClaims(System.Security.Claims.ClaimsPrincipal,Fluxer.Net.FluxerBaseClient)">
-            <Summary>
-            Get Fluxer specific claims for a claim user.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder)">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthHandler">
-            <Summary>
-            Asp.net oauth handler for Fluxer.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthHandler.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Fluxer.Net.OAuth.FluxerOAuthOptions},Microsoft.Extensions.Logging.ILoggerFactory,System.Text.Encodings.Web.UrlEncoder,Microsoft.AspNetCore.Authentication.ISystemClock)">
-            <Summary>
-            Create asp.net oauth handler for Fluxer.
-            </Summary>
-        </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthUser">
-            <inheritdoc />
-        </member>
-        <member name="P:Fluxer.Net.OAuth.FluxerOAuthUser.Email">
-            <inheritdoc />
-        </member>
-        <member name="P:Fluxer.Net.OAuth.FluxerOAuthUser.IsVerified">
-            <inheritdoc />
-        </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthUserJson">
-            <inheritdoc />
-        </member>
-        <member name="P:Fluxer.Net.OAuth.FluxerOAuthUserJson.Email">
-            <inheritdoc />
-        </member>
-        <member name="P:Fluxer.Net.OAuth.FluxerOAuthUserJson.IsVerified">
-            <inheritdoc />
-        </member>
-        <member name="P:Fluxer.Net.OAuth.IFluxerOAuthUser.Email">
-            <summary>
-            The email address of the user.
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.OAuth.IFluxerOAuthUser.IsVerified">
-            <summary>
-            Whether the user has verified their email.
-            </summary>
-        </member>
         <member name="T:Fluxer.Net.RateLimiting.RateLimitBucket">
             <summary>
             Represents a sliding window rate limit bucket for API requests
@@ -7095,29 +7258,19 @@
             <returns>The HTTP status code of the response.</returns>
             <exception cref="T:Fluxer.Net.Extensions.FluxerApiException">Thrown when <paramref name="throwOnNonSuccess"/> is true and the API returns a non-success status code.</exception>
         </member>
-        <member name="T:Fluxer.Net.AllowedMentionsRequest">
+        <member name="T:Fluxer.Net.ChannelPinsQuery">
             <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/schema/src/domains/message/SharedMessageSchemas.tsx#L34"/>
+            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L314"/>
             </remarks>
         </member>
-        <member name="P:Fluxer.Net.AllowedMentionsRequest.Parse">
+        <member name="P:Fluxer.Net.ChannelPinsQuery.Limit">
             <summary>
-            Types of mentions to parse from content
+            Maximum number of pinned messages to return (1-50)
             </summary>
         </member>
-        <member name="P:Fluxer.Net.AllowedMentionsRequest.Users">
+        <member name="P:Fluxer.Net.ChannelPinsQuery.Before">
             <summary>
-            Array of user IDs to mention (max 100)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.AllowedMentionsRequest.Roles">
-            <summary>
-            Array of role IDs to mention (max 100)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.AllowedMentionsRequest.RepliedUser">
-            <summary>
-            Whether to mention the author of the replied message
+            Get pinned messages before this timestamp
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.Requests.EmbedAuthorRequest.Name">
@@ -7220,21 +7373,6 @@
             Array of field objects (max 25)
             </summary>
         </member>
-        <member name="T:Fluxer.Net.ChannelPinsQuery">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L314"/>
-            </remarks>
-        </member>
-        <member name="P:Fluxer.Net.ChannelPinsQuery.Limit">
-            <summary>
-            Maximum number of pinned messages to return (1-50)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.ChannelPinsQuery.Before">
-            <summary>
-            Get pinned messages before this timestamp
-            </summary>
-        </member>
         <member name="P:Fluxer.Net.GlobalSearchMessagesRequest.ContextChannelId">
             <summary>
             Channel ID for context when searching across multiple channels
@@ -7249,6 +7387,51 @@
             <summary>
             Specific channel IDs to search in
             </summary>
+        </member>
+        <member name="T:Fluxer.Net.BulkCreateGuildStickersRequest">
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/schema/src/domains/guild/GuildRequestSchemas.tsx#L235C14-L235C43"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.CreateGuildBanRequest.BanDurationSeconds">
+            <summary>
+            Duration of the ban in seconds
+            (0 or null for permanent, or anything greater than zero for it to be temporary)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.CreateGuildBanRequest.DeleteMessageDays">
+            <summary>
+            Number of days of messages to delete from the banned user (0-7)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.CreateGuildBanRequest.Reason">
+            <summary>
+            The reason for the ban (max 512 characters)
+            </summary>
+        </member>
+        <member name="T:Fluxer.Net.CreateGuildRoleRequest">
+            <summary>
+            <para>Request body for creating a role in a guild.</para>
+            <c>POST /guilds/{guild_id}/roles</c>
+            </summary>
+            <remarks>
+            <see href="https://docs.fluxer.app/resources/guilds#guildrolecreaterequest"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.CreateGuildRoleRequest.Color">
+            <summary>
+            Color as an integer (e.g: 0xff0000 for red)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.CreateGuildRoleRequest.Name">
+            <summary>
+            The name of the role (1-100 characters)
+            </summary>
+        </member>
+        <member name="T:Fluxer.Net.CreateGuildStickerRequest">
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/schema/src/domains/guild/GuildRequestSchemas.tsx#L210"/>
+            </remarks>
         </member>
         <member name="P:Fluxer.Net.GuildAuditLogListRequest.Limit">
             <summary>
@@ -7275,94 +7458,74 @@
             Filter entries by the type of action
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildBanCreateRequest.BanDurationSeconds">
-            <summary>
-            Duration of the ban in seconds
-            (0 or null for permanent, or anything greater than zero for it to be temporary)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.GuildBanCreateRequest.DeleteMessageDays">
-            <summary>
-            Number of days of messages to delete from the banned user (0-7)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.GuildBanCreateRequest.Reason">
-            <summary>
-            The reason for the ban (max 512 characters)
-            </summary>
-        </member>
-        <member name="T:Fluxer.Net.GuildRoleCreateRequest">
-            <summary>
-            <para>Request body for creating a role in a guild.</para>
-            <c>POST /guilds/{guild_id}/roles</c>
-            </summary>
-            <remarks>
-            <see href="https://docs.fluxer.app/resources/guilds#guildrolecreaterequest"/>
-            </remarks>
-        </member>
-        <member name="P:Fluxer.Net.GuildRoleCreateRequest.Color">
-            <summary>
-            Color as an integer (e.g: 0xff0000 for red)
-            </summary>
-        </member>
-        <member name="P:Fluxer.Net.GuildRoleCreateRequest.Name">
-            <summary>
-            The name of the role (1-100 characters)
-            </summary>
-        </member>
-        <member name="T:Fluxer.Net.GuildRoleUpdateRequest">
+        <member name="T:Fluxer.Net.UpdateGuildRoleRequest">
             <summary>
             <c>PATCH /guilds/{guild_id}/roles/{role_id}</c>
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildRoleUpdateRequest.Color">
+        <member name="P:Fluxer.Net.UpdateGuildRoleRequest.Color">
             <summary>
             The color of the role as an integer
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildRoleUpdateRequest.Hoist">
+        <member name="P:Fluxer.Net.UpdateGuildRoleRequest.Hoist">
             <summary>
             Whether the role should be displayed separately in the member list
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildRoleUpdateRequest.HoistPosition">
+        <member name="P:Fluxer.Net.UpdateGuildRoleRequest.HoistPosition">
             <summary>
             The position of the role in the hoisted member list
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildRoleUpdateRequest.Mentionable">
+        <member name="P:Fluxer.Net.UpdateGuildRoleRequest.Mentionable">
             <summary>
             Whether the role can be mentioned by anyone
             </summary>
         </member>
-        <member name="P:Fluxer.Net.GuildRoleUpdateRequest.Name">
+        <member name="P:Fluxer.Net.UpdateGuildRoleRequest.Name">
             <summary>
             The name of the role (1-100 characters)
             </summary>
         </member>
-        <member name="T:Fluxer.Net.GuildStickerBulkCreateRequest">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/schema/src/domains/guild/GuildRequestSchemas.tsx#L235C14-L235C43"/>
-            </remarks>
-        </member>
-        <member name="T:Fluxer.Net.GuildStickerCreateRequest">
-            <remarks>
-            <see href="https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/schema/src/domains/guild/GuildRequestSchemas.tsx#L210"/>
-            </remarks>
-        </member>
-        <member name="T:Fluxer.Net.GuildStickerUpdateRequest">
+        <member name="T:Fluxer.Net.UpdateGuildStickerRequest">
             <remarks>
             <see href="https://github.com/fluxerapp/fluxer/blob/38146cc2babb504bfa9e71f61a60dd57ab2c1b67/packages/schema/src/domains/guild/GuildRequestSchemas.tsx#L227"/>
             </remarks>
         </member>
-        <member name="T:Fluxer.Net.GuildVanityUrlUpdateRequest">
+        <member name="T:Fluxer.Net.UpdateGuildVanityUrlRequest">
             <remarks>
             <see href="https://docs.fluxer.app/resources/guilds#guildvanityurlupdaterequest"/>
             </remarks>
         </member>
-        <member name="P:Fluxer.Net.GuildVanityUrlUpdateRequest.Code">
+        <member name="P:Fluxer.Net.UpdateGuildVanityUrlRequest.Code">
             <summary>
             The new vanity Url code (2-32 characters, alphanumeric and hyphens)
+            </summary>
+        </member>
+        <member name="T:Fluxer.Net.AllowedMentionsRequest">
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/schema/src/domains/message/SharedMessageSchemas.tsx#L34"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.AllowedMentionsRequest.Parse">
+            <summary>
+            Types of mentions to parse from content
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.AllowedMentionsRequest.Users">
+            <summary>
+            Array of user IDs to mention (max 100)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.AllowedMentionsRequest.Roles">
+            <summary>
+            Array of role IDs to mention (max 100)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.AllowedMentionsRequest.RepliedUser">
+            <summary>
+            Whether to mention the author of the replied message
             </summary>
         </member>
         <member name="T:Fluxer.Net.MessageReferenceRequest">
@@ -7639,32 +7802,95 @@
             <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L160"/>
             </remarks>
         </member>
-        <member name="T:Fluxer.Net.MessageUpdateRequest">
+        <member name="T:Fluxer.Net.UpdateMessageRequest">
             <remarks>
             <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/api/src/channel/MessageTypes.tsx#L32"/>
             </remarks>
         </member>
-        <member name="P:Fluxer.Net.MessageUpdateRequest.Content">
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Content">
             <summary>
             The message content (up to 2000 characters)
             </summary>
         </member>
-        <member name="P:Fluxer.Net.MessageUpdateRequest.Embeds">
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Embeds">
             <summary>
             Array of embed objects to include in the message
             </summary>
         </member>
-        <member name="P:Fluxer.Net.MessageUpdateRequest.AllowedMentions">
+        <member name="P:Fluxer.Net.UpdateMessageRequest.AllowedMentions">
             <summary>
             Controls which mentions trigger notifications
             </summary>
         </member>
-        <member name="P:Fluxer.Net.MessageUpdateRequest.Flags">
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Flags">
             <summary>
             Message flags bitfield
             </summary>
         </member>
-        <member name="P:Fluxer.Net.MessageUpdateRequest.Attachments">
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Attachments">
+            <summary>
+            Array of attachment objects to keep or add
+            </summary>
+        </member>
+    </members>
+</doc>
+ions">
+            <summary>
+            File extensions to exclude
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.MessageSearchRequest.SortBy">
+            <summary>
+            Field to sort results by
+            </summary>
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L134"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.MessageSearchRequest.SortOrder">
+            <summary>
+            Sort order for results
+            </summary>
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L147"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.MessageSearchRequest.IncludeNsfw">
+            <summary>
+            Whether to include NSFW channel results
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.MessageSearchRequest.MessageSearchScope">
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/d843d6f3f8a0bd850673ba55036354093977109f/packages/schema/src/domains/message/MessageRequestSchemas.tsx#L160"/>
+            </remarks>
+        </member>
+        <member name="T:Fluxer.Net.UpdateMessageRequest">
+            <remarks>
+            <see href="https://github.com/fluxerapp/fluxer/blob/848269a4d4df7349acfc861ff926b17fe4c4a548/packages/api/src/channel/MessageTypes.tsx#L32"/>
+            </remarks>
+        </member>
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Content">
+            <summary>
+            The message content (up to 2000 characters)
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Embeds">
+            <summary>
+            Array of embed objects to include in the message
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.UpdateMessageRequest.AllowedMentions">
+            <summary>
+            Controls which mentions trigger notifications
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Flags">
+            <summary>
+            Message flags bitfield
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.UpdateMessageRequest.Attachments">
             <summary>
             Array of attachment objects to keep or add
             </summary>

--- a/Fluxer.Net/Gateway/Data/Channels/ChannelGatewayData.cs
+++ b/Fluxer.Net/Gateway/Data/Channels/ChannelGatewayData.cs
@@ -5,67 +5,10 @@ namespace Fluxer.Net.Gateway.Data.Channels;
 /// <summary>
 /// Gateway channel data matching the ChannelResponse API model
 /// </summary>
-public class ChannelGatewayData
+public class ChannelGatewayData : ChannelJson
 {
-    [JsonProperty("id")]
-    public ulong Id { get; set; }
-
-    [JsonProperty("guild_id")]
-    public ulong? GuildId { get; set; }
-
-    [JsonProperty("name")]
-    public string? Name { get; set; }
-
-    [JsonProperty("topic")]
-    public string? Topic { get; set; }
-
-    [JsonProperty("url")]
-    public string? Url { get; set; }
-
-    [JsonProperty("icon")]
-    public string? Icon { get; set; }
-
-    [JsonProperty("owner_id")]
-    public ulong? OwnerId { get; set; }
-
-    [JsonProperty("type")]
-    public int Type { get; set; }
-
-    [JsonProperty("position")]
-    public int? Position { get; set; }
-
-    [JsonProperty("parent_id")]
-    public ulong? ParentId { get; set; }
-
-    [JsonProperty("bitrate")]
-    public int? Bitrate { get; set; }
-
-    [JsonProperty("user_limit")]
-    public int? UserLimit { get; set; }
-
-    [JsonProperty("rtc_region")]
-    public string? RtcRegion { get; set; }
-
-    [JsonProperty("last_message_id")]
-    public ulong? LastMessageId { get; set; }
-
-    [JsonProperty("last_pin_timestamp")]
-    public DateTime? LastPinTimestamp { get; set; }
-
-    [JsonProperty("permission_overwrites")]
-    public List<ChannelOverwriteResponse>? PermissionOverwrites { get; set; }
-
     [JsonProperty("recipients")]
     public List<UserJson>? Recipients { get; set; }
-
-    [JsonProperty("nsfw")]
-    public bool IsNsfw { get; set; }
-
-    [JsonProperty("rate_limit_per_user")]
-    public int? RateLimitPerUser { get; set; }
-
-    [JsonProperty("nicks")]
-    public Dictionary<string, string>? Nicks { get; set; }
 }
 
 /// <summary>

--- a/Fluxer.Net/Gateway/Data/Guilds/GuildGatewayData.cs
+++ b/Fluxer.Net/Gateway/Data/Guilds/GuildGatewayData.cs
@@ -4,72 +4,6 @@ using Newtonsoft.Json;
 namespace Fluxer.Net.Gateway.Data.Guilds;
 
 /// <summary>
-/// The nested guild properties object sent inside a GUILD_CREATE payload.
-/// </summary>
-public class GuildCreateProperties
-{
-    [JsonProperty("id")]
-    public ulong Id { get; set; }
-
-    [JsonProperty("name")]
-    public string Name { get; set; } = null!;
-
-    [JsonProperty("icon")]
-    public string? Icon { get; set; }
-
-    [JsonProperty("banner")]
-    public string? Banner { get; set; }
-
-    [JsonProperty("splash")]
-    public string? Splash { get; set; }
-
-    [JsonProperty("vanity_url_code")]
-    public string? VanityUrlCode { get; set; }
-
-    [JsonProperty("owner_id")]
-    public ulong OwnerId { get; set; }
-
-    [JsonProperty("system_channel_id")]
-    public ulong? SystemChannelId { get; set; }
-
-    [JsonProperty("system_channel_flags")]
-    public int SystemChannelFlags { get; set; }
-
-    [JsonProperty("rules_channel_id")]
-    public ulong? RulesChannelId { get; set; }
-
-    [JsonProperty("afk_channel_id")]
-    public ulong? AfkChannelId { get; set; }
-
-    [JsonProperty("afk_timeout")]
-    public int AfkTimeout { get; set; }
-
-    [JsonProperty("features")]
-    public List<string> Features { get; set; } = new();
-
-    [JsonProperty("verification_level")]
-    public int VerificationLevel { get; set; }
-
-    [JsonProperty("mfa_level")]
-    public int MfaLevel { get; set; }
-
-    [JsonProperty("nsfw_level")]
-    public int NsfwLevel { get; set; }
-
-    [JsonProperty("explicit_content_filter")]
-    public int ExplicitContentFilter { get; set; }
-
-    [JsonProperty("default_message_notifications")]
-    public int DefaultMessageNotifications { get; set; }
-
-    [JsonProperty("disabled_operations")]
-    public int DisabledOperations { get; set; }
-
-    [JsonProperty("max_presences")]
-    public int? MaxPresences { get; set; }
-}
-
-/// <summary>
 /// Gateway data for GUILD_CREATE and GUILD_UPDATE events.
 /// Contains the full guild state including channels, members, roles, and nested guild properties.
 /// When <see cref="Unavailable"/> is true the guild is temporarily unavailable (outage)
@@ -112,7 +46,7 @@ public class GuildGatewayData
     /// Nested guild properties (name, icon, owner, settings, etc.).
     /// </summary>
     [JsonProperty("properties")]
-    public GuildCreateProperties? Properties { get; set; }
+    public GuildJson? Properties { get; set; }
 
     /// <summary>
     /// Channels present in the guild at the time of the event.

--- a/Fluxer.Net/Gateway/Data/Guilds/GuildMemberGatewayData.cs
+++ b/Fluxer.Net/Gateway/Data/Guilds/GuildMemberGatewayData.cs
@@ -1,51 +1,8 @@
-using Newtonsoft.Json;
-
 namespace Fluxer.Net.Gateway.Data.Guilds;
 
 /// <summary>
 /// Gateway guild member data matching the GuildMemberResponse API model
 /// </summary>
-public class GuildMemberGatewayData
+public class GuildMemberGatewayData : GuildMemberJson
 {
-    [JsonProperty("user")]
-    public UserJson User { get; set; } = null!;
-
-    [JsonProperty("nick")]
-    public string? Nick { get; set; }
-
-    [JsonProperty("avatar")]
-    public string? Avatar { get; set; }
-
-    [JsonProperty("banner")]
-    public string? Banner { get; set; }
-
-    [JsonProperty("accent_color")]
-    public int? AccentColor { get; set; }
-
-    [JsonProperty("roles")]
-    public List<ulong> Roles { get; set; } = new();
-
-    [JsonProperty("joined_at")]
-    public DateTime JoinedAt { get; set; }
-
-    [JsonProperty("join_source_type")]
-    public int? JoinSourceType { get; set; }
-
-    [JsonProperty("source_invite_code")]
-    public string? SourceInviteCode { get; set; }
-
-    [JsonProperty("inviter_id")]
-    public ulong? InviterId { get; set; }
-
-    [JsonProperty("mute")]
-    public bool IsMuted { get; set; }
-
-    [JsonProperty("deaf")]
-    public bool IsDeafened { get; set; }
-
-    /// <summary>
-    /// Guild ID for context (added for gateway events)
-    /// </summary>
-    [JsonProperty("guild_id")]
-    public ulong? GuildId { get; set; }
 }

--- a/Fluxer.Net/Gateway/Data/ReadyGatewayData.cs
+++ b/Fluxer.Net/Gateway/Data/ReadyGatewayData.cs
@@ -6,22 +6,31 @@ public class ReadyGatewayData
 {
     [JsonProperty("members")]
     public GuildMemberJson[] Members { get; set; }
+
     [JsonProperty("notes")]
     public Dictionary<string, string> Notes { get; set; }
+
     [JsonProperty("private_channels")]
     public object[] PrivateChannels { get; set; }
+
     [JsonProperty("relationships")]
     public object[] Relationships { get; set; }
+
     [JsonProperty("session_id")]
     public string SessionId { get; set; }
+
     [JsonProperty("guilds")]
     public GuildJson[] Guilds { get; set; }
+
     [JsonProperty("user")]
     public UserJson User { get; set; }
+
     [JsonProperty("user_settings")]
     public UserSettingsJson UserSettings { get; set; }
+
     [JsonProperty("v")]
     public string Version { get; set; }
+
     // [JsonProperty("read_states")]
     // public object[] ReadStates { get; set; }
 }

--- a/Fluxer.Net/Gateway/GatewayClient.cs
+++ b/Fluxer.Net/Gateway/GatewayClient.cs
@@ -461,15 +461,17 @@ public partial class GatewayClient : IDisposable
                     if (data != null)
                     {
                         GuildIds = data.Guilds.Select(x => x.Id).ToHashSet();
-                        Guilds = new ConcurrentDictionary<ulong, SocketGuild>(data.Guilds.ToDictionary(x => x.Id, x => SocketGuild.Create(_client, x)));
                         Channels.Clear();
                         Roles.Clear();
                         CurrentMembers.Clear();
+                        Guilds.Clear();
                         foreach (var m in data.Members)
                         {
                             if (data.User.Id == m.UserId)
                                 CurrentMembers.TryAdd(m.GuildId, SocketGuildMember.Create(_client, m));
                         }
+                        Guilds = new ConcurrentDictionary<ulong, SocketGuild>(data.Guilds.ToDictionary(x => x.Id, x => SocketGuild.Create(_client, x, CurrentMembers[x.Id])));
+
                         _sessionId = data.SessionId;
                         _isConnecting = false; // Connection successfully established
                         _reconnectAttemptCount = 0; // Reset backoff counter

--- a/Fluxer.Net/Gateway/GatewayClient.cs
+++ b/Fluxer.Net/Gateway/GatewayClient.cs
@@ -12,6 +12,7 @@ using Fluxer.Net.Gateway.Packets;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog.Core;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -47,7 +48,7 @@ public partial class GatewayClient : IDisposable
     private WebsocketClient _webSocket;
     private readonly Stopwatch _gatewayDuration = new();
 
-    public HashSet<ulong> Guilds { get; internal set; } = new HashSet<ulong>();
+    public HashSet<ulong> GuildIds { get; internal set; } = new HashSet<ulong>();
 
     /// <summary>
     /// Current sequence number for gateway events. Used for resuming connections without data loss.
@@ -96,6 +97,14 @@ public partial class GatewayClient : IDisposable
         _logger = client.Config.GatewaySerilog;
         _logger.Information("Initialized Fluxer.Net gateway client ({AssemblyVersion}) (API {ApiVersion})", Assembly.GetExecutingAssembly().GetName().Version, _client.Config.Version);
     }
+    #endregion
+
+    #region Cache
+
+    public ConcurrentDictionary<ulong, SocketGuild> Guilds = new ConcurrentDictionary<ulong, SocketGuild>();
+    public ConcurrentDictionary<ulong, SocketChannel> Channels = new ConcurrentDictionary<ulong, SocketChannel>();
+    public ConcurrentDictionary<ulong, SocketRole> Roles = new ConcurrentDictionary<ulong, SocketRole>();
+    public ConcurrentDictionary<ulong, SocketGuildMember> CurrentMembers = new ConcurrentDictionary<ulong, SocketGuildMember>();
     #endregion
 
     #region Gateway
@@ -193,7 +202,7 @@ public partial class GatewayClient : IDisposable
                 return;
             }
 
-            var login = new GatewayPacket
+            GatewayPacket login = new GatewayPacket
             {
                 OpCode = FluxerOpCode.Identify,
                 Data = JToken.FromObject(new IdentifyGatewayData(_client.RawToken)
@@ -266,7 +275,7 @@ public partial class GatewayClient : IDisposable
         double random = SharedRandom.NextDouble();
 #endif
         var jitter = random * 0.3 * baseDelay; // Add up to 30% jitter
-        var totalDelay = TimeSpan.FromSeconds(baseDelay + jitter);
+        TimeSpan totalDelay = TimeSpan.FromSeconds(baseDelay + jitter);
 
         _logger.Information("Reconnection attempt #{Attempt} - waiting {Delay:F1} seconds before reconnecting",
             _reconnectAttemptCount, totalDelay.TotalSeconds);
@@ -293,7 +302,7 @@ public partial class GatewayClient : IDisposable
         try
         {
             // Pre-parse to check for InvalidSession opcode (which has a boolean payload instead of an object)
-            var preCheck = JObject.Parse(message);
+            JObject preCheck = JObject.Parse(message);
             var opCode = preCheck["op"]?.Value<int>();
             var dispatch = preCheck["t"]?.Value<string>();
 
@@ -451,7 +460,16 @@ public partial class GatewayClient : IDisposable
                     ReadyGatewayData? data = p.Data.ToObject<ReadyGatewayData>(FluxerClient._serializer);
                     if (data != null)
                     {
-                        Guilds = data.Guilds.Select(x => x.Id).ToHashSet();
+                        GuildIds = data.Guilds.Select(x => x.Id).ToHashSet();
+                        Guilds = new ConcurrentDictionary<ulong, SocketGuild>(data.Guilds.ToDictionary(x => x.Id, x => SocketGuild.Create(_client, x)));
+                        Channels.Clear();
+                        Roles.Clear();
+                        CurrentMembers.Clear();
+                        foreach (var m in data.Members)
+                        {
+                            if (data.User.Id == m.UserId)
+                                CurrentMembers.TryAdd(m.GuildId, SocketGuildMember.Create(_client, m));
+                        }
                         _sessionId = data.SessionId;
                         _isConnecting = false; // Connection successfully established
                         _reconnectAttemptCount = 0; // Reset backoff counter
@@ -567,7 +585,10 @@ public partial class GatewayClient : IDisposable
                 {
                     ChannelGatewayData? data = p.Data.ToObject<ChannelGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        Channels.TryAdd(data.Id, SocketChannel.Create(_client, data, data.GuildId.Value));
                         ChannelCreate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("CHANNEL_CREATE event received but data could not be cast to ChannelGatewayData");
                 }
@@ -576,7 +597,11 @@ public partial class GatewayClient : IDisposable
                 {
                     ChannelGatewayData? data = p.Data.ToObject<ChannelGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        if (Channels.TryGetValue(data.Id, out var channel))
+                            channel.Update(_client, data);
                         ChannelUpdate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("CHANNEL_UPDATE event received but data could not be cast to ChannelGatewayData");
                 }
@@ -585,7 +610,10 @@ public partial class GatewayClient : IDisposable
                 {
                     ChannelGatewayData? data = p.Data.ToObject<ChannelGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        Channels.TryRemove(data.Id, out _);
                         ChannelDelete?.Invoke(data);
+                    }
                     else
                         _logger.Warning("CHANNEL_DELETE event received but data could not be cast to ChannelGatewayData");
                 }
@@ -818,7 +846,23 @@ public partial class GatewayClient : IDisposable
                     GuildGatewayData? data = p.Data.ToObject<GuildGatewayData>(FluxerClient._serializer);
                     if (data != null)
                     {
-                        Guilds.Add(data.Id);
+                        GuildIds.Add(data.Id);
+                        if (!data.Unavailable.GetValueOrDefault())
+                        {
+                            SocketGuildMember member = SocketGuildMember.Create(_client, data.Members.First());
+                            if (Guilds.TryAdd(data.Id, SocketGuild.Create(_client, data.Properties, member)))
+                                CurrentMembers.TryAdd(data.Id, member);
+
+                            foreach (var c in data.Channels)
+                            {
+                                Channels.TryAdd(c.Id, SocketChannel.Create(_client, c, data.Id));
+                            }
+                            foreach (var r in data.Roles)
+                            {
+                                Roles.TryAdd(r.Id, SocketRole.Create(_client, r, data.Id));
+                            }
+                        }
+
                         GuildCreate?.Invoke(data);
                     }
                     else
@@ -829,7 +873,11 @@ public partial class GatewayClient : IDisposable
                 {
                     GuildGatewayData? data = p.Data.ToObject<GuildGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        if (Guilds.TryGetValue(data.Id, out var guild))
+                            guild.Update(_client, data.Properties);
                         GuildUpdate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("GUILD_UPDATE event received but data could not be cast to GuildGatewayData");
                 }
@@ -841,12 +889,24 @@ public partial class GatewayClient : IDisposable
                     {
                         if (data.Unavailable.GetValueOrDefault())
                         {
-                            Guilds.Add(data.Id);
+                            GuildIds.Add(data.Id);
                             GuildCreate?.Invoke(new GuildGatewayData { Id = data.Id, Unavailable = true });
                         }
                         else
                         {
-                            Guilds.Remove(data.Id);
+                            Guilds.TryRemove(data.Id, out _);
+                            CurrentMembers.TryRemove(data.Id, out _);
+                            foreach (var c in Channels.Values)
+                            {
+                                if (c.GuildId == data.Id)
+                                    Channels.TryRemove(c.Id, out _);
+                            }
+                            foreach (var r in Roles.Values)
+                            {
+                                if (r.GuildId == data.Id)
+                                    Roles.TryRemove(r.Id, out _);
+                            }
+                            GuildIds.Remove(data.Id);
                             GuildDelete?.Invoke(data);
                         }
                     }
@@ -867,7 +927,12 @@ public partial class GatewayClient : IDisposable
                 {
                     Gateway.Data.Guilds.GuildMemberGatewayData? data = p.Data.ToObject<Gateway.Data.Guilds.GuildMemberGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        if (CurrentMembers.TryGetValue(data.GuildId, out var member) && member.UserId == data.UserId)
+                            member.Update(_client, data);
+
                         GuildMemberUpdate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("GUILD_MEMBER_UPDATE event received but data could not be cast to GuildMemberGatewayData");
                 }
@@ -885,7 +950,10 @@ public partial class GatewayClient : IDisposable
                 {
                     GuildRoleGatewayData? data = p.Data.ToObject<GuildRoleGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        Roles.TryAdd(data.Role.Id, SocketRole.Create(_client, data.Role, data.GuildId));
                         GuildRoleCreate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("GUILD_ROLE_CREATE event received but data could not be cast to GuildRoleGatewayData");
                 }
@@ -894,7 +962,11 @@ public partial class GatewayClient : IDisposable
                 {
                     GuildRoleGatewayData? data = p.Data.ToObject<GuildRoleGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        if (Roles.TryGetValue(data.Role.Id, out var role))
+                            role.Update(_client, data.Role);
                         GuildRoleUpdate?.Invoke(data);
+                    }
                     else
                         _logger.Warning("GUILD_ROLE_UPDATE event received but data could not be cast to GuildRoleGatewayData");
                 }
@@ -903,7 +975,10 @@ public partial class GatewayClient : IDisposable
                 {
                     GuildRoleDeleteGatewayData? data = p.Data.ToObject<GuildRoleDeleteGatewayData>(FluxerClient._serializer);
                     if (data != null)
+                    {
+                        Roles.TryRemove(data.RoleId, out _);
                         GuildRoleDelete?.Invoke(data);
+                    }
                     else
                         _logger.Warning("GUILD_ROLE_DELETE event received but data could not be cast to GuildRoleDeleteGatewayData");
                 }
@@ -1088,7 +1163,7 @@ public partial class GatewayClient : IDisposable
                 _logger.Information("No valid session ID available. Sending IDENTIFY instead of RESUME.");
 
                 // Send fresh IDENTIFY packet since we don't have a session to resume
-                var identifyPacket = new GatewayPacket
+                GatewayPacket identifyPacket = new GatewayPacket
                 {
                     OpCode = FluxerOpCode.Identify,
                     Data = JToken.FromObject(new IdentifyGatewayData(_client.RawToken)
@@ -1108,7 +1183,7 @@ public partial class GatewayClient : IDisposable
             }
 
             var timeSinceLastAttempt = DateTime.Now - _lastGatewayReEstablishAttempt;
-            var requiredDelay = TimeSpan.FromSeconds(_client.Config.ReconnectAttemptDelay);
+            TimeSpan requiredDelay = TimeSpan.FromSeconds(_client.Config.ReconnectAttemptDelay);
 
             if (timeSinceLastAttempt < requiredDelay)
             {
@@ -1122,7 +1197,7 @@ public partial class GatewayClient : IDisposable
 
             _logger.Information("Attempting to resume session {SessionId} with sequence {Sequence}", _sessionId, _sequence);
 
-            var packet = new GatewayPacket()
+            GatewayPacket packet = new GatewayPacket()
             {
                 OpCode = FluxerOpCode.Resume,
                 Data = JToken.FromObject(new ReconnectGatewayData()
@@ -1160,7 +1235,7 @@ public partial class GatewayClient : IDisposable
             return true; // Allow reconnection for non-Fluxer codes
         }
 
-        var fluxerCode = (FluxerCloseCode)closeCode;
+        FluxerCloseCode fluxerCode = (FluxerCloseCode)closeCode;
         _logger.Warning("Received Fluxer close code: {CloseCode} ({CodeValue}) - {Description}",
             fluxerCode, closeCode, description ?? "No description");
 
@@ -1322,7 +1397,7 @@ public partial class GatewayClient : IDisposable
                 await Task.Delay(_heartbeatInterval + jitter, cancellationToken);
 
                 _logger.Verbose("Sending heartbeat with sequence {Sequence}", _sequence);
-                var packet = new HeartbeatPacket()
+                HeartbeatPacket packet = new HeartbeatPacket()
                 {
                     Data = _sequence,
                     OpCode = FluxerOpCode.Heartbeat,
@@ -1350,7 +1425,7 @@ public partial class GatewayClient : IDisposable
     /// </remarks>
     public void SetStatus(Status status, UserCustomStatusJson? custom)
     {
-        var packet = new GatewayPacket()
+        GatewayPacket packet = new GatewayPacket()
         {
             Data = JToken.FromObject(new PresenceUpdateGatewayData(status, custom)),
             OpCode = FluxerOpCode.PresenceUpdate

--- a/Fluxer.Net/Gateway/GatewayClient.cs
+++ b/Fluxer.Net/Gateway/GatewayClient.cs
@@ -465,10 +465,13 @@ public partial class GatewayClient : IDisposable
                         Roles.Clear();
                         CurrentMembers.Clear();
                         Guilds.Clear();
-                        foreach (var m in data.Members)
+                        if (data.Members != null)
                         {
-                            if (data.User.Id == m.UserId)
-                                CurrentMembers.TryAdd(m.GuildId, SocketGuildMember.Create(_client, m));
+                            foreach (var m in data.Members)
+                            {
+                                if (data.User.Id == m.UserId)
+                                    CurrentMembers.TryAdd(m.GuildId, SocketGuildMember.Create(_client, m));
+                            }
                         }
                         Guilds = new ConcurrentDictionary<ulong, SocketGuild>(data.Guilds.ToDictionary(x => x.Id, x => SocketGuild.Create(_client, x, CurrentMembers[x.Id])));
 

--- a/Fluxer.Net/OAuth/FluxerOAuthClient.cs
+++ b/Fluxer.Net/OAuth/FluxerOAuthClient.cs
@@ -33,8 +33,6 @@ public class FluxerOAuthClient : FluxerBaseClient
         base.Rest = new ApiClient(this);
     }
 
-    public FluxerConfig Config { get; }
-
     public ulong ClientId => base.Id;
     public string ClientSecret => base.Token;
 

--- a/Fluxer.Net/OAuth/FluxerOAuthHandler.cs
+++ b/Fluxer.Net/OAuth/FluxerOAuthHandler.cs
@@ -51,7 +51,7 @@ public partial class FluxerOAuthHandler : OAuthHandler<FluxerOAuthOptions>
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
+        using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
 
@@ -72,10 +72,10 @@ public partial class FluxerOAuthHandler : OAuthHandler<FluxerOAuthOptions>
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using JsonDocument payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
-        var principal = new ClaimsPrincipal(identity);
-        var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
+        ClaimsPrincipal principal = new ClaimsPrincipal(identity);
+        OAuthCreatingTicketContext context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
         context.RunClaimActions();
         await Events.CreatingTicket(context);
         return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);

--- a/Fluxer.Net/Rest/ApiClient.cs
+++ b/Fluxer.Net/Rest/ApiClient.cs
@@ -405,6 +405,12 @@ public class ApiClient
 
     #region Channels API
 
+    public async Task<Channel> CreatePrivateChannelAsync(CreatePrivateChannelRequest req)
+    {
+        var json = await MakeFluxerApiRequestAsync<ChannelJson, CreatePrivateChannelRequest>(HttpMethod.Post, $"/users/@me/channels", req, true);
+        return Channel.Create(_client, json);
+    }
+
     public async Task<Channel> GetChannelAsync(ulong channelId)
     {
         var json = await MakeFluxerApiRequestAsync<ChannelJson>(HttpMethod.Get, $"/channels/{channelId}", true);
@@ -783,9 +789,9 @@ public class ApiClient
         return json.Select(x => Channel.Create(_client, x));
     }
 
-    public async Task<Channel> CreateChannelAsync<TRequest>(ulong guildId, CreateChannelRequest data)
+    public async Task<Channel> CreateGuildChannelAsync(ulong guildId, CreateGuildChannelRequest data)
     {
-        var json = await MakeFluxerApiRequestAsync<ChannelJson, CreateChannelRequest>(HttpMethod.Post, $"/guilds/{guildId}/channels", data, true);
+        var json = await MakeFluxerApiRequestAsync<ChannelJson, CreateGuildChannelRequest>(HttpMethod.Post, $"/guilds/{guildId}/channels", data, true);
         return Channel.Create(_client, json);
     }
 

--- a/Fluxer.Net/Rest/ApiClient.cs
+++ b/Fluxer.Net/Rest/ApiClient.cs
@@ -457,7 +457,7 @@ public class ApiClient
         MessageRequest req = new MessageRequest
         {
             Content = content,
-            Embeds = embeds.ToArray(),
+            Embeds = embeds?.ToArray(),
             MessageReference = reference,
             AllowedMentions = allowedMentions,
             Flags = flags,
@@ -1148,7 +1148,7 @@ public class ApiClient
         MessageRequest req = new MessageRequest
         {
             Content = content,
-            Embeds = embeds.ToArray(),
+            Embeds = embeds?.ToArray(),
             MessageReference = reference,
             AllowedMentions = allowedMentions,
             Flags = flags,
@@ -1168,7 +1168,7 @@ public class ApiClient
         MessageRequest req = new MessageRequest
         {
             Content = content,
-            Embeds = embeds.ToArray(),
+            Embeds = embeds?.ToArray(),
             MessageReference = reference,
             AllowedMentions = allowedMentions,
             Flags = flags,
@@ -1189,7 +1189,7 @@ public class ApiClient
         MessageRequest req = new MessageRequest
         {
             Content = content,
-            Embeds = embeds.ToArray(),
+            Embeds = embeds?.ToArray(),
             MessageReference = reference,
             AllowedMentions = allowedMentions,
             Flags = flags,

--- a/Fluxer.Net/Rest/ApiClient.cs
+++ b/Fluxer.Net/Rest/ApiClient.cs
@@ -137,7 +137,7 @@ public class ApiClient
     {
         var rawContent = JsonConvert.SerializeObject(data, FluxerClient._serializerSettings);
         _logger.Verbose("Sending {@Enums} to {Route}", rawContent, route);
-        var req = new HttpRequestMessage()
+        HttpRequestMessage req = new HttpRequestMessage()
         {
             Method = method,
             RequestUri = new(_config.RealApiBaseUrl + route)
@@ -146,7 +146,7 @@ public class ApiClient
 
         if (otherFormData != null)
         {
-            var form = new MultipartFormDataContent
+            MultipartFormDataContent form = new MultipartFormDataContent
             {
                 {
                     new StringContent(rawContent,
@@ -203,7 +203,7 @@ public class ApiClient
     internal async Task<TResponse> InternalMakeFluxerApiRequestFormAsync<TResponse>(HttpMethod method, string route, bool throwOnNonSuccess = false,
         Dictionary<string, string?>? formData = null)
     {
-        var req = new HttpRequestMessage()
+        HttpRequestMessage req = new HttpRequestMessage()
         {
             Method = method,
             RequestUri = new(_config.RealApiBaseUrl + route)
@@ -212,7 +212,7 @@ public class ApiClient
 
         if (formData != null)
         {
-            var form = new MultipartFormDataContent();
+            MultipartFormDataContent form = new MultipartFormDataContent();
             foreach (var (key, value) in formData)
             {
                 form.Add(new StringContent(value), key);
@@ -246,7 +246,7 @@ public class ApiClient
     public async Task<HttpStatusCode> MakeFluxerApiRequestAsync<TSend>(HttpMethod method, string route, TSend data, bool throwOnNonSuccess = false, bool authorize = true)
     {
         _logger.Verbose("Sending {@Enums} to {Route}", data, route);
-        var req = new HttpRequestMessage()
+        HttpRequestMessage req = new HttpRequestMessage()
         {
             Method = method,
             Content = new StringContent(JsonConvert.SerializeObject(data, FluxerClient._serializerSettings),
@@ -288,7 +288,7 @@ public class ApiClient
 
     internal async Task<TResponse> InternalMakeFluxerApiRequestAsync<TResponse>(HttpMethod method, string route, bool throwOnNonSuccess, bool authorize, string accessToken)
     {
-        var req = new HttpRequestMessage()
+        HttpRequestMessage req = new HttpRequestMessage()
         {
             Method = method,
             RequestUri = new(_config.RealApiBaseUrl + route)
@@ -322,7 +322,7 @@ public class ApiClient
     /// <exception cref="FluxerApiException">Thrown when <paramref name="throwOnNonSuccess"/> is true and the API returns a non-success status code.</exception>
     public async Task<HttpStatusCode> MakeFluxerApiRequestRawAsync(HttpMethod method, string route, bool throwOnNonSuccess = false, bool authorize = true)
     {
-        var req = new HttpRequestMessage()
+        HttpRequestMessage req = new HttpRequestMessage()
         {
             Method = method,
             RequestUri = new(_config.RealApiBaseUrl + route)
@@ -468,7 +468,7 @@ public class ApiClient
                 req, true);
             return Message.Create(_client, jsonAttach);
         }
-        var form = new List<KeyValuePair<string, (HttpContent content, string? filename)>>();
+        List<KeyValuePair<string, (HttpContent content, string? filename)>> form = new List<KeyValuePair<string, (HttpContent content, string? filename)>>();
         for (int i = 0; i < attachments.Count; i++)
         {
             attachments[i].Id = (ulong)i;

--- a/Fluxer.Net/Rest/FluxerWebhookClient.cs
+++ b/Fluxer.Net/Rest/FluxerWebhookClient.cs
@@ -44,8 +44,6 @@ public class FluxerWebhookClient : FluxerBaseClient
         Rest = new ApiClient(this);
     }
 
-    public FluxerConfig Config { get; }
-
     public new ulong Id => base.Id;
     public new string Token => base.Token;
 

--- a/Fluxer.Net/Rest/Helpers/GuildHelpers.cs
+++ b/Fluxer.Net/Rest/Helpers/GuildHelpers.cs
@@ -24,7 +24,7 @@ public static class GuildHelpers
         => guild.Client.Rest.GetChannelsAsync(guild.Id);
 
     public static Task<Channel> CreateChannelAsync(this Guild guild, CreateGuildChannelRequest request)
-        => guild.Client.Rest.CreateGuildChannelAsync<ChannelJson>(guild.Id, request);
+        => guild.Client.Rest.CreateGuildChannelAsync(guild.Id, request);
 
     public static Task<IEnumerable<GuildEmoji>> GetEmojisAsync(this Guild guild)
         => guild.Client.Rest.GetEmojisAsync(guild.Id);

--- a/Fluxer.Net/Rest/Helpers/GuildHelpers.cs
+++ b/Fluxer.Net/Rest/Helpers/GuildHelpers.cs
@@ -23,8 +23,8 @@ public static class GuildHelpers
     public static Task<IEnumerable<Channel>> GetChannelsAsync(this Guild guild)
         => guild.Client.Rest.GetChannelsAsync(guild.Id);
 
-    public static Task<Channel> CreateChannelAsync(this Guild guild, CreateChannelRequest request)
-        => guild.Client.Rest.CreateChannelAsync<ChannelJson>(guild.Id, request);
+    public static Task<Channel> CreateChannelAsync(this Guild guild, CreateGuildChannelRequest request)
+        => guild.Client.Rest.CreateGuildChannelAsync<ChannelJson>(guild.Id, request);
 
     public static Task<IEnumerable<GuildEmoji>> GetEmojisAsync(this Guild guild)
         => guild.Client.Rest.GetEmojisAsync(guild.Id);

--- a/Fluxer.Net/Rest/Helpers/PrivateChannelHelpers.cs
+++ b/Fluxer.Net/Rest/Helpers/PrivateChannelHelpers.cs
@@ -31,4 +31,7 @@ public static class PrivateChannelHelpers
          {
              Name = name,
          });
+
+    public static Task CloseAsync(this DMChannel channel)
+        => channel.Client.Rest.DeleteChannelAsync(channel.Id);
 }

--- a/Fluxer.Net/Rest/Helpers/PrivateChannelHelpers.cs
+++ b/Fluxer.Net/Rest/Helpers/PrivateChannelHelpers.cs
@@ -1,0 +1,34 @@
+﻿namespace Fluxer.Net;
+
+public static class PrivateChannelHelpers
+{
+    public static Task AddUserAsync(this GroupChannel channel, User user)
+        => channel.Client.Rest.AddRecipientAsync(channel.Id, user.Id);
+
+    public static Task AddUserAsync(this GroupChannel channel, ulong userId)
+        => channel.Client.Rest.AddRecipientAsync(channel.Id, userId);
+
+    public static Task RemoveUserAsync(this GroupChannel channel, User user)
+        => channel.Client.Rest.RemoveRecipientAsync(channel.Id, user.Id);
+
+    public static Task RemoveUserAsync(this GroupChannel channel, ulong userId)
+        => channel.Client.Rest.RemoveRecipientAsync(channel.Id, userId);
+
+    public static Task TransferOwnershipAsync(this GroupChannel channel, User user)
+        => channel.Client.Rest.UpdateChannelAsync(channel.Id, new ChannelJson
+        {
+            OwnerId = user.Id
+        });
+
+    public static Task TransferOwnershipAsync(this GroupChannel channel, ulong userId)
+        => channel.Client.Rest.UpdateChannelAsync(channel.Id, new ChannelJson
+        {
+            OwnerId = userId
+        });
+
+    public static Task EditNameAsync(this GroupChannel channel, string name)
+         => channel.Client.Rest.UpdateChannelAsync(channel.Id, new ChannelJson
+         {
+             Name = name,
+         });
+}

--- a/Fluxer.Net/Rest/Helpers/UserHelpers.cs
+++ b/Fluxer.Net/Rest/Helpers/UserHelpers.cs
@@ -1,0 +1,34 @@
+﻿namespace Fluxer.Net;
+
+public static class UserHelpers
+{
+    public static async Task<DMChannel> GetOrCreateDMChannelAsync(this User user)
+    {
+        var chan = await user.Client.Rest.CreatePrivateChannelAsync(new CreatePrivateChannelRequest
+        {
+            RecipientId = user.Id
+        });
+
+        return (DMChannel)chan;
+    }
+
+    public static async Task<GroupChannel> CreateGroupChannelAsync(this CurrentUser user, HashSet<User> users)
+    {
+        var chan = await user.Client.Rest.CreatePrivateChannelAsync(new CreatePrivateChannelRequest
+        {
+            Recipients = users.Select(x => x.Id).ToHashSet()
+        });
+
+        return (GroupChannel)chan;
+    }
+
+    public static async Task<GroupChannel> CreateGroupChannelAsync(this CurrentUser user, HashSet<ulong> userIds)
+    {
+        var chan = await user.Client.Rest.CreatePrivateChannelAsync(new CreatePrivateChannelRequest
+        {
+            Recipients = userIds
+        });
+
+        return (GroupChannel)chan;
+    }
+}

--- a/Fluxer.Net/Rest/Requests/Channels/ChannelPinsQuery.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/ChannelPinsQuery.cs
@@ -17,7 +17,7 @@ public class ChannelPinsQuery
 
     public string BuildQuery()
     {
-        var list = new List<string>(2);
+        List<string> list = new List<string>(2);
         if (Limit.HasValue && Limit.Value > 0)
         {
             list.Add($"limit={Limit.Value}");

--- a/Fluxer.Net/Rest/Requests/Channels/CreateCategoryChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreateCategoryChannelRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Fluxer.Net;
 
-public class CreateCategoryChannelRequest : CreateChannelRequest
+public class CreateCategoryChannelRequest : CreateGuildChannelRequest
 {
     public override string Type => "GUILD_CATEGORY";
 

--- a/Fluxer.Net/Rest/Requests/Channels/CreateChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreateChannelRequest.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Fluxer.Net;
 
-public abstract class CreateChannelRequest
+public abstract class CreateGuildChannelRequest
 {
     [JsonProperty("type")]
     public abstract string Type { get; }

--- a/Fluxer.Net/Rest/Requests/Channels/CreateLinkChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreateLinkChannelRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Fluxer.Net;
 
-public class CreateLinkChannelRequest : CreateChannelRequest
+public class CreateLinkChannelRequest : CreateGuildChannelRequest
 {
     public override string Type => "GUILD_LINK";
 

--- a/Fluxer.Net/Rest/Requests/Channels/CreatePrivateChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreatePrivateChannelRequest.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Fluxer.Net;
+
+public class CreatePrivateChannelRequest
+{
+    [JsonProperty("recipient_id")]
+    public ulong? RecipientId { get; set; }
+
+    [JsonProperty("recipients")]
+    public HashSet<ulong>? Recipients { get; set; }
+}

--- a/Fluxer.Net/Rest/Requests/Channels/CreateTextChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreateTextChannelRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Fluxer.Net;
 
-public class CreateTextChannelRequest : CreateChannelRequest
+public class CreateTextChannelRequest : CreateGuildChannelRequest
 {
     public override string Type => "GUILD_TEXT";
 

--- a/Fluxer.Net/Rest/Requests/Channels/CreateVoiceChannelRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Channels/CreateVoiceChannelRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Fluxer.Net;
 
-public class CreateVoiceChannelRequest : CreateChannelRequest
+public class CreateVoiceChannelRequest : CreateGuildChannelRequest
 {
     public override string Type => "GUILD_VOICE";
 

--- a/Fluxer.Net/Rest/Requests/Guilds/CreateGuildEmojiRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Guilds/CreateGuildEmojiRequest.cs
@@ -12,7 +12,7 @@ public class CreateGuildEmojiRequest
 
     public void ImageFromStream(Stream stream)
     {
-        using var ms = new MemoryStream();
+        using MemoryStream ms = new MemoryStream();
         stream.CopyTo(ms);
         ImageBase64 = Convert.ToBase64String(ms.ToArray());
     }

--- a/Fluxer.Net/Rest/Requests/Guilds/CreateGuildRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Guilds/CreateGuildRequest.cs
@@ -18,7 +18,7 @@ public class CreateGuildRequest
 
     public void IconFromStream(Stream stream)
     {
-        using var ms = new MemoryStream();
+        using MemoryStream ms = new MemoryStream();
         stream.CopyTo(ms);
         IconBase64 = Convert.ToBase64String(ms.ToArray());
     }

--- a/Fluxer.Net/Rest/Requests/Guilds/CreateGuildStickerRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Guilds/CreateGuildStickerRequest.cs
@@ -21,7 +21,7 @@ public class CreateGuildStickerRequest
 
     public void ImageFromStream(Stream stream)
     {
-        using var ms = new MemoryStream();
+        using MemoryStream ms = new MemoryStream();
         stream.CopyTo(ms);
         ImageBase64 = Convert.ToBase64String(ms.ToArray());
     }


### PR DESCRIPTION
- Fix exception when sending messages due to null embeds whoops.
- Partial experimental support for websocket cache, you can use `Client.Gateway.Guilds/Roles/Channels/CurrentMembers`
- Changed previous Guilds to GuildIds.
- Added `Mention` property to User, Member, Role and Channel.
- Added `GetDefaultAvatarUrl`, `GetAvatarUrl` and `GetAvatarOrDefaultUrl` to User, Member and Webhook.
- Added `GetBannerUrl` to UserProfile and CurrentUser.
- Fixed CurrentUser not inheriting ICurrentUser.
- Added `GetCurrentName` to User and Member.
- Added `GetOrCreateDMChannelAsync` to User and `CreateGroupChannelAsync` to CurrentUser.
- Added `AddUserAsync`, `RemoveUserAsync`, `TransferOwnershipAsync` and `EditNameAsync` to GroupChannel.
- Added `CloseAsync` to DMChannel.