### PR TITLE
Use long to parse bigger limits thant int32

### DIFF
--- a/Fluxer.Net/Data/Misc/IInstance.cs
+++ b/Fluxer.Net/Data/Misc/IInstance.cs
@@ -122,7 +122,7 @@ public interface IInstanceRule
 {
     string Id { get; }
 
-    IDictionary<string, int> Overrides { get; }
+    IDictionary<string, long> Overrides { get; }
 }
 public interface IInstancePush
 {

--- a/Fluxer.Net/Data/Misc/Instance.cs
+++ b/Fluxer.Net/Data/Misc/Instance.cs
@@ -347,9 +347,9 @@ public class InstanceRule : IInstanceRule
     public string Id { get; internal set; }
 
     /// <inheritdoc />
-    public Dictionary<string, int> Overrides { get; internal set; }
+    public Dictionary<string, long> Overrides { get; internal set; }
 
-    IDictionary<string, int> IInstanceRule.Overrides => Overrides;
+    IDictionary<string, long> IInstanceRule.Overrides => Overrides;
 }
 /// <inheritdoc />
 public class InstancePush : IInstancePush

--- a/Fluxer.Net/Data/Misc/InstanceJson.cs
+++ b/Fluxer.Net/Data/Misc/InstanceJson.cs
@@ -272,9 +272,9 @@ public class InstanceRuleJson : IInstanceRule
 
     /// <inheritdoc />
     [JsonProperty("overrides")]
-    public Dictionary<string, int> Overrides { get; set; }
+    public Dictionary<string, long> Overrides { get; set; }
 
-    IDictionary<string, int> IInstanceRule.Overrides => Overrides;
+    IDictionary<string, long> IInstanceRule.Overrides => Overrides;
 }
 
 /// <inheritdoc />

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -774,7 +774,7 @@
             Configure the logger for the command service.
             </summary>
         </member>
-        <member name="P:Fluxer.Net.Commands.CommandServiceConfig.OwnerIds">
+        <member name="P:Fluxer.Net.Commands.CommandServiceConfig.OwnerIDs">
             <summary>
             Extra owner IDs when checking RequireOwner precondition.
             </summary>
@@ -10896,51 +10896,6 @@
         </member>
         <member name="M:Fluxer.Net.OAuth.FluxerOAuthClient.RevokeRefreshTokenAsync(System.String)">
             <inheritdoc cref="M:Fluxer.Net.Rest.FluxerApiClient.RevokeOAuthRefreshTokenAsync(System.UInt64,System.String,System.String)" />
-        </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthExtensions">
-            <Summary>
-            Extension methods for handling fluxer oauth client.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxerClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,Fluxer.Net.FluxerConfig)">
-            <Summary>
-            Add Fluxer client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxerOAuth(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.UInt64,System.String,Fluxer.Net.FluxerConfig)">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.GetFluxerClaims(System.Security.Claims.ClaimsPrincipal,Fluxer.Net.FluxerBaseClient)">
-            <Summary>
-            Get Fluxer specific claims for a claim user.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthExtensions.AddFluxer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder,System.String,System.String,System.Action{Fluxer.Net.OAuth.FluxerOAuthOptions})">
-            <Summary>
-            Add Fluxer oauth client on dependency injection service.
-            </Summary>
-        </member>
-        <member name="T:Fluxer.Net.OAuth.FluxerOAuthHandler">
-            <Summary>
-            Asp.net oauth handler for Fluxer.
-            </Summary>
-        </member>
-        <member name="M:Fluxer.Net.OAuth.FluxerOAuthHandler.#ctor(Microsoft.Extensions.Options.IOptionsMonitor{Fluxer.Net.OAuth.FluxerOAuthOptions},Microsoft.Extensions.Logging.ILoggerFactory,System.Text.Encodings.Web.UrlEncoder,Microsoft.AspNetCore.Authentication.ISystemClock)">
-            <Summary>
-            Create asp.net oauth handler for Fluxer.
-            </Summary>
         </member>
         <member name="T:Fluxer.Net.RateLimiting.RateLimitBucket">
             <summary>


### PR DESCRIPTION
Parsing bigger limits, for example 5 Gb:

`
[20:49:07 INF] Trying to login with url: https://api-fluxer.mydomain.smh
2026-08-25T20:49:07.475609353Z [20:49:07 ERR] Hosting failed to start
2026-08-25T20:49:07.475640775Z Newtonsoft.Json.JsonReaderException: JSON integer 5242880000 is too large or small for an Int32. Path 'limits.rules[0].overrides.max_attachment_file_size', line 1, position 2206.
`