### PR TITLE
v2.7.5

### DIFF
--- a/Fluxer.Net/Commands/Info/CommandInfo.cs
+++ b/Fluxer.Net/Commands/Info/CommandInfo.cs
@@ -326,8 +326,8 @@ public class CommandInfo
     internal string GetLogText(ICommandContext context)
     {
         if (context.Guild != null)
-            return $"\"{Name}\" for {context.User} in {context.Guild}/{context.Channel}";
+            return $"\"{Name}\" for {context.User.Username}#{context.User.Discriminator} in {context.Guild.Name}/{context.Channel.Name}";
         else
-            return $"\"{Name}\" for {context.User} in {context.Channel}";
+            return $"\"{Name}\" for {context.User.Username}#{context.User.Discriminator} in {context.Channel.Name}";
     }
 }

--- a/Fluxer.Net/Data/Voice/IVoiceState.cs
+++ b/Fluxer.Net/Data/Voice/IVoiceState.cs
@@ -2,31 +2,78 @@
 
 public interface IVoiceState
 {
+    /// <summary>
+    /// Voice connection session.
+    /// </summary>
     string SessionId { get; }
 
+    /// <summary>
+    /// User id that is connected.
+    /// </summary>
     ulong UserId { get; }
 
+    /// <summary>
+    /// Channel id connected to.
+    /// </summary>
     ulong? ChannelId { get; }
 
+    /// <summary>
+    /// Voice connection id.
+    /// </summary>
     string? ConnectionId { get; }
 
+    /// <summary>
+    /// User is deafened in the guild.
+    /// </summary>
     bool IsDeaf { get; }
 
+    /// <summary>
+    /// User is muted in the guild.
+    /// </summary>
     bool IsMute { get; }
 
+    /// <summary>
+    /// Guild id for the voice channel.
+    /// </summary>
     ulong? GuildId { get; }
 
+    /// <summary>
+    /// User connected with mobile.
+    /// </summary>
     bool IsMobile { get; }
 
+    /// <summary>
+    /// User is self deafend.
+    /// </summary>
     bool IsSelfDeaf { get; }
 
+    /// <summary>
+    /// User is self muted.
+    /// </summary>
     bool IsSelfMute { get; }
 
+    /// <summary>
+    /// User is streaming.
+    /// </summary>
     bool IsSelfStream { get; }
 
+    /// <summary>
+    /// User is using video.
+    /// </summary>
     bool IsSelfVideo { get; }
 
+    /// <summary>
+    /// User can't speak in voice.
+    /// </summary>
+    bool IsSuppressed { get; }
+
+    /// <summary>
+    /// Keys used for streaming.
+    /// </summary>
     string[] ViewerStreamKeys { get; }
 
+    /// <summary>
+    /// Member for the voice connection.
+    /// </summary>
     IGuildMember Member { get; }
 }

--- a/Fluxer.Net/Data/Voice/VoiceState.cs
+++ b/Fluxer.Net/Data/Voice/VoiceState.cs
@@ -1,48 +1,52 @@
 ﻿namespace Fluxer.Net;
 
+/// <inheritdoc />
 public class VoiceState : Entity, IVoiceState
 {
     /// <inheritdoc />
-    public string SessionId { get; set; }
+    public string SessionId { get; internal set; }
 
     /// <inheritdoc />
-    public ulong UserId { get; set; }
+    public ulong UserId { get; internal set; }
 
     /// <inheritdoc />
-    public ulong? ChannelId { get; set; }
+    public ulong? ChannelId { get; internal set; }
 
     /// <inheritdoc />
-    public string? ConnectionId { get; set; }
+    public string? ConnectionId { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsDeaf { get; set; }
+    public bool IsDeaf { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsMute { get; set; }
+    public bool IsMute { get; internal set; }
 
     /// <inheritdoc />
-    public ulong? GuildId { get; set; }
+    public ulong? GuildId { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsMobile { get; set; }
+    public bool IsMobile { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsSelfDeaf { get; set; }
+    public bool IsSelfDeaf { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsSelfMute { get; set; }
+    public bool IsSelfMute { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsSelfStream { get; set; }
+    public bool IsSelfStream { get; internal set; }
 
     /// <inheritdoc />
-    public bool IsSelfVideo { get; set; }
+    public bool IsSelfVideo { get; internal set; }
 
     /// <inheritdoc />
-    public string[] ViewerStreamKeys { get; set; }
+    public bool IsSuppressed { get; internal set; }
 
     /// <inheritdoc />
-    public GuildMember Member { get; set; }
+    public string[] ViewerStreamKeys { get; internal set; }
+
+    /// <inheritdoc />
+    public GuildMember Member { get; internal set; }
 
     IGuildMember IVoiceState.Member => Member;
 
@@ -78,6 +82,7 @@ public class VoiceState : Entity, IVoiceState
         IsSelfMute = json.IsSelfMute;
         IsSelfStream = json.IsSelfStream;
         IsSelfVideo = json.IsSelfVideo;
+        IsSuppressed = json.IsSuppressed;
         ViewerStreamKeys = json.ViewerStreamKeys;
         Member = GuildMember.Create(client, json.Member);
     }

--- a/Fluxer.Net/Data/Voice/VoiceStateJson.cs
+++ b/Fluxer.Net/Data/Voice/VoiceStateJson.cs
@@ -54,6 +54,10 @@ public class VoiceStateJson : IVoiceState
     public bool IsSelfVideo { get; set; }
 
     /// <inheritdoc />
+    [JsonProperty("suppress")]
+    public bool IsSuppressed { get; set; }
+
+    /// <inheritdoc />
     [JsonProperty("viewer_stream_keys")]
     public string[] ViewerStreamKeys { get; set; }
 

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -8961,6 +8961,81 @@
             The emoji associated with this RTC region
             </summary>
         </member>
+        <member name="P:Fluxer.Net.IVoiceState.SessionId">
+            <summary>
+            Voice connection session.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.UserId">
+            <summary>
+            User id that is connected.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.ChannelId">
+            <summary>
+            Channel id connected to.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.ConnectionId">
+            <summary>
+            Voice connection id.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsDeaf">
+            <summary>
+            User is deafened in the guild.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsMute">
+            <summary>
+            User is muted in the guild.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.GuildId">
+            <summary>
+            Guild id for the voice channel.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsMobile">
+            <summary>
+            User connected with mobile.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsSelfDeaf">
+            <summary>
+            User is self deafend.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsSelfMute">
+            <summary>
+            User is self muted.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsSelfStream">
+            <summary>
+            User is streaming.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsSelfVideo">
+            <summary>
+            User is using video.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.IsSuppressed">
+            <summary>
+            User can't speak in voice.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.ViewerStreamKeys">
+            <summary>
+            Keys used for streaming.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.IVoiceState.Member">
+            <summary>
+            Member for the voice connection.
+            </summary>
+        </member>
         <member name="T:Fluxer.Net.RtcRegion">
             <inheritdoc />
         </member>
@@ -9002,6 +9077,9 @@
             <param name="guild"></param>
             <returns></returns>
         </member>
+        <member name="T:Fluxer.Net.VoiceState">
+            <inheritdoc />
+        </member>
         <member name="P:Fluxer.Net.VoiceState.SessionId">
             <inheritdoc />
         </member>
@@ -9036,6 +9114,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.VoiceState.IsSelfVideo">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.VoiceState.IsSuppressed">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.VoiceState.ViewerStreamKeys">
@@ -9089,6 +9170,9 @@
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.VoiceStateJson.IsSelfVideo">
+            <inheritdoc />
+        </member>
+        <member name="P:Fluxer.Net.VoiceStateJson.IsSuppressed">
             <inheritdoc />
         </member>
         <member name="P:Fluxer.Net.VoiceStateJson.ViewerStreamKeys">
@@ -12708,6 +12792,23 @@
             <param name="refreshToken"></param>
             <returns></returns>
         </member>
+        <member name="M:Fluxer.Net.Rest.FluxerApiClient.SearchGuildMessagesAsync(System.UInt64,Fluxer.Net.Rest.GlobalSearchMessagesRequest)">
+            <inheritdoc cref="M:Fluxer.Net.Rest.FluxerApiClient.SearchChannelMessagesAsync(System.UInt64,Fluxer.Net.Rest.GlobalSearchMessagesRequest)"/>
+        </member>
+        <member name="M:Fluxer.Net.Rest.FluxerApiClient.SearchGuildChannelMessagesAsync(System.UInt64,System.UInt64,Fluxer.Net.Rest.GlobalSearchMessagesRequest)">
+            <inheritdoc cref="M:Fluxer.Net.Rest.FluxerApiClient.SearchChannelMessagesAsync(System.UInt64,Fluxer.Net.Rest.GlobalSearchMessagesRequest)"/>
+        </member>
+        <member name="M:Fluxer.Net.Rest.FluxerApiClient.SearchChannelMessagesAsync(System.UInt64,Fluxer.Net.Rest.GlobalSearchMessagesRequest)">
+            <summary>
+            Search messages globally using either guild or channel.
+            </summary>
+            <remarks>
+            Page needs to be 1 and message scope should not be changed when using bots.
+            </remarks>
+            <param name="channelId"></param>
+            <param name="request"></param>
+            <returns></returns>
+        </member>
         <member name="T:Fluxer.Net.Rest.ApiLimits">
             <summary>
             API limits for the current instance.
@@ -13329,157 +13430,162 @@
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.Page">
             <summary>
-            Page number for pagination
+            Page number for pagination.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.MaxId">
             <summary>
-            Maximum message ID to include in results
+            Maximum message ID to include in results.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.MinId">
             <summary>
-            Minimum message ID to include in results
+            Minimum message ID to include in results.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.Content">
             <summary>
-            Text content to search for
+            Text content to search for.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.Contents">
             <summary>
-            Multiple content queries to search for
+            Multiple content queries to search for.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExactPhrases">
             <summary>
-            Exact phrases that must appear contiguously in message content
+            Exact phrases that must appear contiguously in message content.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ChannelIds">
             <summary>
-            Channel IDs to search in
+            Channel IDs to search in.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeChannelIds">
             <summary>
-            Channel IDs to exclude from search
+            Channel IDs to exclude from search.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.AuthorTypes">
             <summary>
-            Author types to filter by
+            Author types to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeAuthorTypes">
             <summary>
-            Author types to exclude
+            Author types to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.AuthorId">
             <summary>
-            Author user IDs to filter by
+            Author user IDs to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeAuthorId">
             <summary>
-            Author user IDs to exclude
+            Author user IDs to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.MentionUserIds">
             <summary>
-            User IDs that must be mentioned
+            User IDs that must be mentioned.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeMentionUserIds">
             <summary>
-            User IDs that must not be mentioned
+            User IDs that must not be mentioned.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.MentionEveryone">
             <summary>
-            Filter by whether message mentions everyone
+            Filter by whether message mentions everyone.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.Pinned">
             <summary>
-            Filter by pinned status
+            Filter by pinned status.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.HasContentType">
             <summary>
-            Content types the message must have
+            Content types the message must have.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeContentType">
             <summary>
-            Content types the message must not have
+            Content types the message must not have.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.EmbedType">
             <summary>
-            Embed types to filter by
+            Embed types to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeEmbedType">
             <summary>
-            Embed types to exclude
+            Embed types to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.EmbedProvider">
             <summary>
-            Embed providers to filter by
+            Embed providers to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeEmbedProvider">
             <summary>
-            Embed providers to exclude
+            Embed providers to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.LinkHostnames">
             <summary>
-            Link hostnames to filter by
+            Link hostnames to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeLinkHostnames">
             <summary>
-            Link hostnames to exclude
+            Link hostnames to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.AttachmentFilenames">
             <summary>
-            Attachment filenames to filter by
+            Attachment filenames to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeAttachmentFilenames">
             <summary>
-            Attachment filenames to exclude
+            Attachment filenames to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.AttachmentExtensions">
             <summary>
-            File extensions to filter by
+            File extensions to filter by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.ExcludeAttachmentExtensions">
             <summary>
-            File extensions to exclude
+            File extensions to exclude.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.SortBy">
             <summary>
-            Field to sort results by
+            Field to sort results by.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.SortOrder">
             <summary>
-            Sort order for results
+            Sort order for results.
             </summary>
         </member>
         <member name="P:Fluxer.Net.Rest.MessageSearchRequest.IncludeNsfw">
             <summary>
-            Whether to include NSFW channel results
+            Whether to include NSFW channel results.
+            </summary>
+        </member>
+        <member name="P:Fluxer.Net.Rest.MessageSearchRequest.MessageSearchScope">
+            <summary>
+            This should not be changed when using bots.
             </summary>
         </member>
         <member name="T:Fluxer.Net.Rest.RestClientQueryParams">

--- a/Fluxer.Net/Rest/ApiClient.cs
+++ b/Fluxer.Net/Rest/ApiClient.cs
@@ -2638,6 +2638,7 @@ public class FluxerApiClient
 
     #region Global Search
 
+    /// <inheritdoc cref="SearchChannelMessagesAsync(ulong, GlobalSearchMessagesRequest)"/>
     public async Task<GlobalSearch> SearchGuildMessagesAsync(ulong guildId, GlobalSearchMessagesRequest request)
     {
         request.ContextGuildId = guildId;
@@ -2645,6 +2646,7 @@ public class FluxerApiClient
         return GlobalSearch.Create(_client, json);
     }
 
+    /// <inheritdoc cref="SearchChannelMessagesAsync(ulong, GlobalSearchMessagesRequest)"/>
     public async Task<GlobalSearch> SearchGuildChannelMessagesAsync(ulong guildId, ulong channelId, GlobalSearchMessagesRequest request)
     {
         request.ContextGuildId = guildId;
@@ -2653,6 +2655,15 @@ public class FluxerApiClient
         return GlobalSearch.Create(_client, json);
     }
 
+    /// <summary>
+    /// Search messages globally using either guild or channel.
+    /// </summary>
+    /// <remarks>
+    /// Page needs to be 1 and message scope should not be changed when using bots.
+    /// </remarks>
+    /// <param name="channelId"></param>
+    /// <param name="request"></param>
+    /// <returns></returns>
     public async Task<GlobalSearch> SearchChannelMessagesAsync(ulong channelId, GlobalSearchMessagesRequest request)
     {
         request.ContextChannelId = channelId;

--- a/Fluxer.Net/Rest/Requests/GlobalSearchMessagesRequest.cs
+++ b/Fluxer.Net/Rest/Requests/GlobalSearchMessagesRequest.cs
@@ -13,7 +13,7 @@ public class GlobalSearchMessagesRequest : MessageSearchRequest
     /// <summary>
     /// Guild ID for context when searching across multiple guilds
     /// </summary>
-    [JsonProperty("context_build_ids")]
+    [JsonProperty("context_guild_id")]
     public ulong? ContextGuildId { get; set; }
 
     /// <summary>

--- a/Fluxer.Net/Rest/Requests/Messages/MessageSearchRequest.cs
+++ b/Fluxer.Net/Rest/Requests/Messages/MessageSearchRequest.cs
@@ -11,191 +11,194 @@ public class MessageSearchRequest
     public int HitsPerPage { get; set; } = 25;
 
     /// <summary>
-    /// Page number for pagination
+    /// Page number for pagination.
     /// </summary>
     [JsonProperty("page")]
     public int Page { get; set; } = 1;
 
     /// <summary>
-    /// Maximum message ID to include in results
+    /// Maximum message ID to include in results.
     /// </summary>
     [JsonProperty("max_id")]
     public ulong? MaxId { get; set; }
 
     /// <summary>
-    /// Minimum message ID to include in results
+    /// Minimum message ID to include in results.
     /// </summary>
     [JsonProperty("min_id")]
     public ulong? MinId { get; set; }
 
     /// <summary>
-    /// Text content to search for
+    /// Text content to search for.
     /// </summary>
     [JsonProperty("content")]
     public string? Content { get; set; }
 
     /// <summary>
-    /// Multiple content queries to search for
+    /// Multiple content queries to search for.
     /// </summary>
     [JsonProperty("Multiple content queries to search for")]
     public HashSet<string>? Contents { get; set; }
 
     /// <summary>
-    /// Exact phrases that must appear contiguously in message content
+    /// Exact phrases that must appear contiguously in message content.
     /// </summary>
     [JsonProperty("exact_phrases")]
     public HashSet<string>? ExactPhrases { get; set; }
 
     /// <summary>
-    /// Channel IDs to search in
+    /// Channel IDs to search in.
     /// </summary>
     [JsonProperty("channel_id")]
     public HashSet<ulong>? ChannelIds { get; set; }
 
     /// <summary>
-    /// Channel IDs to exclude from search
+    /// Channel IDs to exclude from search.
     /// </summary>
     [JsonProperty("exclude_channel_id")]
     public HashSet<ulong>? ExcludeChannelIds { get; set; }
 
     /// <summary>
-    /// Author types to filter by
+    /// Author types to filter by.
     /// </summary>
     [JsonProperty("author_type")]
     public HashSet<string>? AuthorTypes { get; set; }
 
     /// <summary>
-    /// Author types to exclude
+    /// Author types to exclude.
     /// </summary>
     [JsonProperty("exclude_author_type")]
     public HashSet<string>? ExcludeAuthorTypes { get; set; }
 
     /// <summary>
-    /// Author user IDs to filter by
+    /// Author user IDs to filter by.
     /// </summary>
     [JsonProperty("author_id")]
     public HashSet<ulong>? AuthorId { get; set; }
 
     /// <summary>
-    /// Author user IDs to exclude
+    /// Author user IDs to exclude.
     /// </summary>
     [JsonProperty("exclude_author_id")]
     public HashSet<ulong>? ExcludeAuthorId { get; set; }
 
     /// <summary>
-    /// User IDs that must be mentioned
+    /// User IDs that must be mentioned.
     /// </summary>
     [JsonProperty("mentions")]
     public HashSet<ulong>? MentionUserIds { get; set; }
 
     /// <summary>
-    /// User IDs that must not be mentioned
+    /// User IDs that must not be mentioned.
     /// </summary>
     [JsonProperty("exclude_mentions")]
     public HashSet<ulong>? ExcludeMentionUserIds { get; set; }
 
     /// <summary>
-    /// Filter by whether message mentions everyone
+    /// Filter by whether message mentions everyone.
     /// </summary>
     [JsonProperty("mention_everyone")]
     public bool? MentionEveryone { get; set; }
 
     /// <summary>
-    /// Filter by pinned status
+    /// Filter by pinned status.
     /// </summary>
     [JsonProperty("pinned")]
     public bool? Pinned { get; set; }
 
     /// <summary>
-    /// Content types the message must have
+    /// Content types the message must have.
     /// </summary>
     [JsonProperty("has")]
     public HashSet<string>? HasContentType { get; set; }
 
     /// <summary>
-    /// Content types the message must not have
+    /// Content types the message must not have.
     /// </summary>
     [JsonProperty("exclude_has")]
     public HashSet<string>? ExcludeContentType { get; set; }
 
     /// <summary>
-    /// Embed types to filter by
+    /// Embed types to filter by.
     /// </summary>
     [JsonProperty("embed_type")]
     public HashSet<string>? EmbedType { get; set; }
 
     /// <summary>
-    /// Embed types to exclude
+    /// Embed types to exclude.
     /// </summary>
     [JsonProperty("exclude_embed_type")]
     public HashSet<string>? ExcludeEmbedType { get; set; }
 
     /// <summary>
-    /// Embed providers to filter by
+    /// Embed providers to filter by.
     /// </summary>
     [JsonProperty("embed_provider")]
     public HashSet<string>? EmbedProvider { get; set; }
 
     /// <summary>
-    /// Embed providers to exclude
+    /// Embed providers to exclude.
     /// </summary>
     [JsonProperty("exclude_embed_provider")]
     public HashSet<string>? ExcludeEmbedProvider { get; set; }
 
     /// <summary>
-    /// Link hostnames to filter by
+    /// Link hostnames to filter by.
     /// </summary>
     [JsonProperty("link_hostname")]
     public HashSet<string>? LinkHostnames { get; set; }
 
     /// <summary>
-    /// Link hostnames to exclude
+    /// Link hostnames to exclude.
     /// </summary>
     [JsonProperty("exclude_link_hostname")]
     public HashSet<string>? ExcludeLinkHostnames { get; set; }
 
     /// <summary>
-    /// Attachment filenames to filter by
+    /// Attachment filenames to filter by.
     /// </summary>
     [JsonProperty("attachment_filename")]
     public HashSet<string>? AttachmentFilenames { get; set; }
 
     /// <summary>
-    /// Attachment filenames to exclude
+    /// Attachment filenames to exclude.
     /// </summary>
     [JsonProperty("exclude_attachment_filename")]
     public HashSet<string>? ExcludeAttachmentFilenames { get; set; }
 
     /// <summary>
-    /// File extensions to filter by
+    /// File extensions to filter by.
     /// </summary>
     [JsonProperty("attachment_extension")]
     public HashSet<string>? AttachmentExtensions { get; set; }
 
     /// <summary>
-    /// File extensions to exclude
+    /// File extensions to exclude.
     /// </summary>
     [JsonProperty("exclude_attachment_extension")]
     public HashSet<string>? ExcludeAttachmentExtensions { get; set; }
 
     /// <summary>
-    /// Field to sort results by
+    /// Field to sort results by.
     /// </summary>
     [JsonProperty("sort_by")]
     public string? SortBy { get; set; }
 
     /// <summary>
-    /// Sort order for results
+    /// Sort order for results.
     /// </summary>
     [JsonProperty("sort_order")]
     public string? SortOrder { get; set; }
 
     /// <summary>
-    /// Whether to include NSFW channel results
+    /// Whether to include NSFW channel results.
     /// </summary>
     [JsonProperty("include_nsfw")]
     public bool? IncludeNsfw { get; set; }
 
+    /// <summary>
+    /// This should not be changed when using bots.
+    /// </summary>
     [JsonProperty("scope")]
     public string? MessageSearchScope { get; set; } = "current";
 }


### PR DESCRIPTION
- Updated command error logging to include the user and guild/channel name instead of just placeholder SocketUser/SocketGuild.
- Added xml comment on message search including page needs to be 1 and message scope should not be changed for bots.
- Fix context guild id property when sending message search request.
- Added xml comments for VoiceState and IsSuppressed if user can't speak.