### PR TITLE
Rename mentions of Server to Guild

### DIFF
--- a/Fluxer.Net/Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/Fluxer.Net/Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -4,9 +4,9 @@
 public class RequireBotPermissionAttribute : PreconditionAttribute
 {
     /// <summary>
-    /// Server permission to check for.
+    /// Guild permission to check for.
     /// </summary>
-    private readonly GuildPermission? Server;
+    private readonly GuildPermission? Guild;
 
     /// <summary>
     /// Channel permission to check for.
@@ -15,7 +15,7 @@ public class RequireBotPermissionAttribute : PreconditionAttribute
 
     public RequireBotPermissionAttribute(GuildPermission perm)
     {
-        Server = perm;
+        Guild = perm;
     }
 
     public RequireBotPermissionAttribute(ChannelPermission perm)
@@ -31,12 +31,12 @@ public class RequireBotPermissionAttribute : PreconditionAttribute
 
         SocketGuildMember? member = guild.CurrentMember as SocketGuildMember;
 
-        if (Server.HasValue)
+        if (Guild.HasValue)
         {
-            if (member != null && member.HasPermission(Server.Value))
+            if (member != null && member.HasPermission(Guild.Value))
                 return PreconditionResult.FromSuccess();
 
-            return PreconditionResult.FromError($"Bot needs community permission for **{Server.Value.ToString()}** to use this command.");
+            return PreconditionResult.FromError($"Bot needs community permission for **{Guild.Value.ToString()}** to use this command.");
         }
 
         if (Channel == null)

--- a/Fluxer.Net/Commands/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/Fluxer.Net/Commands/Attributes/Preconditions/RequireContextAttribute.cs
@@ -18,7 +18,7 @@ public class RequireContextAttribute : PreconditionAttribute
     {
         bool isValid = false;
 
-        if ((Contexts & ContextType.Server) != 0)
+        if ((Contexts & ContextType.Community) != 0)
             isValid = context.Channel.GuildId.HasValue;
         if ((Contexts & ContextType.DM) != 0)
             isValid = isValid || context.Channel.Type == ChannelType.Dm;
@@ -37,5 +37,5 @@ public enum ContextType
 {
     DM = 0x01,
     Group = 0x02,
-    Server = 0x03
+    Community = 0x03
 }

--- a/Fluxer.Net/Commands/Attributes/Preconditions/RequireGuildAttribute.cs
+++ b/Fluxer.Net/Commands/Attributes/Preconditions/RequireGuildAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace Fluxer.Net.Commands;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-public class RequireServerAttribute : PreconditionAttribute
+public class RequireGuildAttribute : PreconditionAttribute
 {
     /// <inheritdoc />
     public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)

--- a/Fluxer.Net/Commands/Attributes/Preconditions/RequireGuildOwnerAttribute.cs
+++ b/Fluxer.Net/Commands/Attributes/Preconditions/RequireGuildOwnerAttribute.cs
@@ -1,7 +1,7 @@
 namespace Fluxer.Net.Commands;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-public class RequireServerOwnerAttribute : PreconditionAttribute
+public class RequireGuildOwnerAttribute : PreconditionAttribute
 {
     /// <inheritdoc />
     public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)

--- a/Fluxer.Net/Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/Fluxer.Net/Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -4,9 +4,9 @@
 public class RequireUserPermissionAttribute : PreconditionAttribute
 {
     /// <summary>
-    /// Server/group permission to check for.
+    /// Guild/Group permission to check for.
     /// </summary>
-    private readonly GuildPermission? Server;
+    private readonly GuildPermission? Guild;
 
     /// <summary>
     /// Channel permission to check for.
@@ -15,7 +15,7 @@ public class RequireUserPermissionAttribute : PreconditionAttribute
 
     public RequireUserPermissionAttribute(GuildPermission perm)
     {
-        Server = perm;
+        Guild = perm;
     }
 
     public RequireUserPermissionAttribute(ChannelPermission perm)
@@ -41,12 +41,12 @@ public class RequireUserPermissionAttribute : PreconditionAttribute
 
         SocketGuildMember? member = context.Member as SocketGuildMember;
 
-        if (Server.HasValue)
+        if (Guild.HasValue)
         {
-            if (member != null && member.HasPermission(Server.Value))
+            if (member != null && member.HasPermission(Guild.Value))
                 return PreconditionResult.FromSuccess();
 
-            return PreconditionResult.FromError($"You need community permission for **{Server.Value.ToString()}** to use this command.");
+            return PreconditionResult.FromError($"You need community permission for **{Guild.Value.ToString()}** to use this command.");
         }
 
         if (Channel == null)

--- a/Fluxer.Net/Data/Guilds/PartialGuild.cs
+++ b/Fluxer.Net/Data/Guilds/PartialGuild.cs
@@ -83,7 +83,7 @@ public class PartialGuild : Entity, IPartialGuild
         InviteSplashWidth = json.InviteSplashWidth;
         InviteSplashHeight = json.InviteSplashHeight;
         SplashCardAligment = json.SplashCardAligment;
-        Features = GuildFeatures.FromServer(json);
+        Features = GuildFeatures.FromGuild(json);
     }
 
     /// <inheritdoc />

--- a/Fluxer.Net/Data/Guilds/Settings/GuildFeatures.cs
+++ b/Fluxer.Net/Data/Guilds/Settings/GuildFeatures.cs
@@ -26,7 +26,7 @@ public class GuildFeatures
     public bool IsOperator { get; private set; }
     public bool BlockUnclaimedAccounts { get; private set; }
     public bool HasLargeGuildOverride { get; private set; }
-    public bool IsLargeServer { get; private set; }
+    public bool IsLargeGuild { get; private set; }
 
     internal GuildFeatures()
     {
@@ -116,7 +116,7 @@ public class GuildFeatures
                         data.HasLargeGuildOverride = true;
                         break;
                     case "VERY_LARGE_GUILD":
-                        data.IsLargeServer = true;
+                        data.IsLargeGuild = true;
                         break;
                 }
             }
@@ -125,7 +125,7 @@ public class GuildFeatures
         return data;
     }
 
-    public static GuildFeatures FromServer(PartialGuildJson guild)
+    public static GuildFeatures FromGuild(PartialGuildJson guild)
     {
         return GuildFeatures.Create(guild.Features);
     }

--- a/Fluxer.Net/FluxerNet.xml
+++ b/Fluxer.Net/FluxerNet.xml
@@ -257,9 +257,9 @@
             <param name="command">The command being executed.</param>
             <param name="services">The service collection used for dependency injection.</param>
         </member>
-        <member name="F:Fluxer.Net.Commands.RequireBotPermissionAttribute.Server">
+        <member name="F:Fluxer.Net.Commands.RequireBotPermissionAttribute.Guild">
             <summary>
-            Server permission to check for.
+            Guild permission to check for.
             </summary>
         </member>
         <member name="F:Fluxer.Net.Commands.RequireBotPermissionAttribute.Channel">
@@ -285,6 +285,12 @@
             <inheritdoc />
         </member>
         <member name="M:Fluxer.Net.Commands.RequireGroupOwnerAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.Commands.RequireGuildAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
+            <inheritdoc />
+        </member>
+        <member name="M:Fluxer.Net.Commands.RequireGuildOwnerAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
             <inheritdoc />
         </member>
         <member name="M:Fluxer.Net.Commands.RequireNsfwAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
@@ -319,15 +325,9 @@
         <member name="M:Fluxer.Net.Commands.RequireOwnerAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
             <inheritdoc />
         </member>
-        <member name="M:Fluxer.Net.Commands.RequireServerAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
-            <inheritdoc />
-        </member>
-        <member name="M:Fluxer.Net.Commands.RequireServerOwnerAttribute.CheckPermissionsAsync(Fluxer.Net.Commands.ICommandContext,Fluxer.Net.Commands.CommandInfo,System.IServiceProvider)">
-            <inheritdoc />
-        </member>
-        <member name="F:Fluxer.Net.Commands.RequireUserPermissionAttribute.Server">
+        <member name="F:Fluxer.Net.Commands.RequireUserPermissionAttribute.Guild">
             <summary>
-            Server/group permission to check for.
+            Guild/Group permission to check for.
             </summary>
         </member>
         <member name="F:Fluxer.Net.Commands.RequireUserPermissionAttribute.Channel">
@@ -13171,7 +13171,7 @@
         </member>
         <member name="F:Fluxer.Net.Rest.ApiLimits.MaxGuildMembersLarge">
             <summary>
-            How many more users can join a guild with <see cref="P:Fluxer.Net.GuildFeatures.IsLargeServer"/>.
+            How many more users can join a guild with <see cref="P:Fluxer.Net.GuildFeatures.IsLargeGuild"/>.
             </summary>
         </member>
         <member name="F:Fluxer.Net.Rest.ApiLimits.MaxInviteUses">

--- a/Fluxer.Net/Rest/ApiLimits.cs
+++ b/Fluxer.Net/Rest/ApiLimits.cs
@@ -103,7 +103,7 @@ public class ApiLimits
     public int MaxGuildMembers = 1000000;
 
     /// <summary>
-    /// How many more users can join a guild with <see cref="GuildFeatures.IsLargeServer"/>.
+    /// How many more users can join a guild with <see cref="GuildFeatures.IsLargeGuild"/>.
     /// </summary>
     public int MaxGuildMembersLarge = 10000000;
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -48,7 +48,7 @@ Here is some common ones.
 * @Fluxer.Net.FluxerOAuthUser
 * @Fluxer.Net.FluxerOAuthToken
 
-## Servers
+## Guilds
 * @Fluxer.Net.Guild
 * @Fluxer.Net.GuildMember
 * @Fluxer.Net.Role

--- a/docs/example/samples/precondition.cs
+++ b/docs/example/samples/precondition.cs
@@ -1,5 +1,5 @@
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-public class RequireServerAttribute : PreconditionAttribute
+public class RequireGuildAttribute : PreconditionAttribute
 {
     /// <inheritdoc />
     public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)

--- a/docs/get_started/events.md
+++ b/docs/get_started/events.md
@@ -4,7 +4,7 @@ title: Using Events
 ---
 
 # Using Events
-Using Fluxer.net you can listen for events such as message create, community member joins and member bans.
+Using Fluxer.net you can listen for events such as message create, guild member joins and member bans.
 
 Here is an example of using a message create event, this will let you use `data` for the properties of the incoming message.
 

--- a/docs/guides/commands/preconditions.md
+++ b/docs/guides/commands/preconditions.md
@@ -11,17 +11,17 @@ Preconditions can be used to check for access or permissions when running a comm
 | Attribute | Description |
 |---|---|
 | [Require Owner](xref:Fluxer.Net.Commands.RequireOwnerAttribute) | Only the owner can run the command. |
-| [Require Context](xref:Fluxer.Net.Commands.RequireContextAttribute) | Restrict command to DM, Group or Server. |
+| [Require Context](xref:Fluxer.Net.Commands.RequireContextAttribute) | Restrict command to DM, Group or Community. |
 | [Require DM](xref:Fluxer.Net.Commands.RequireDMAttribute) | Restrict command to DM. |
 | [Require Group](xref:Fluxer.Net.Commands.RequireGroupAttribute) | Restrict command to DM. |
 | [Require Group Owner](xref:Fluxer.Net.Commands.RequireGroupOwnerAttribute) | Only the group owner can run the command. |
 
-## Server
+## Guild
 
 | Attribute | Description |
 |---|---|
-| [Require Server](xref:Fluxer.Net.Commands.RequireServerAttribute) | Restrict command to Server. |
-| [Require Server Owner](xref:Fluxer.Net.Commands.RequireServerOwnerAttribute) | Only the community owner can run the command. |
+| [Require Guild](xref:Fluxer.Net.Commands.RequireGuildAttribute) | Restrict command to Guild. |
+| [Require Guild Owner](xref:Fluxer.Net.Commands.RequireGuildOwnerAttribute) | Only the guild owner can run the command. |
 | [Require Nsfw](xref:Fluxer.Net.Commands.RequireNsfwAttribute) | Restrict command to nsfw channels. |
 | [Require Bot Permission](xref:Fluxer.Net.Commands.RequireBotPermissionAttribute) | Check if current user/bot has a permission. |
 | [Require User Permission](xref:Fluxer.Net.Commands.RequireUserPermissionAttribute) | Check if command user has a permission. |


### PR DESCRIPTION
- This change seeks to make the naming consistent with the API.
- Strings with the word "Server", which are shown to the end-user, have been changed to use "Community" instead.